### PR TITLE
batch-size fix

### DIFF
--- a/src/domyn_swarm/jobs.py
+++ b/src/domyn_swarm/jobs.py
@@ -203,7 +203,7 @@ class SwarmJob(abc.ABC):
         pending_ids: list[int] = []
 
         pbar = tqdm(
-            total=self.batch_size,
+            total=min(self.batch_size, len(seq)),
             desc=f"[{threading.current_thread().name}] Batch request execution",
             dynamic_ncols=True,
             leave=True,


### PR DESCRIPTION
When the batch size exceeds the size of the dataset, `tqdm` displays a progress bar total larger than the actual dataset size.