### PR TITLE
EnvPath subclassing fix

### DIFF
--- a/src/domyn_swarm/utils/env_path.py
+++ b/src/domyn_swarm/utils/env_path.py
@@ -2,9 +2,14 @@ import pydantic_core
 import pathlib
 import os
 
+import sys
 
-class EnvPath(pathlib.Path):
-    _flavour = type(pathlib.Path())._flavour  # Required for subclassing Path
+if sys.platform == "win32":
+    base = pathlib.WindowsPath
+else:
+    base = pathlib.PosixPath
+
+class EnvPath(base):
 
     def __new__(cls, *args, **kwargs):
         raw_path = os.path.expandvars(os.path.join(*map(str, args)))


### PR DESCRIPTION
Installing with `uv tool install domyn-swarn` led to a broken version of domyn-swarm due to EnvPath subclassing. 
Probably the issue is caused by the usage of a different python interpreter. This fix should make EnvPath more robust