### PR TITLE
Perf/cli lazy imports

### DIFF
--- a/src/domyn_swarm/cli/main.py
+++ b/src/domyn_swarm/cli/main.py
@@ -14,17 +14,71 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import sys
 from typing import Annotated
 
 import typer
+from typer.core import TyperGroup
 
-from ..cli.init import init_app
-from ..cli.pool import pool_app
-from .db import db_app
-from .job import job_app
-from .swarm import swarm_app
+# Sub-apps that pull in heavy dependencies (pandas, openai, leptonai, alembic).
+# Imported on first use so light root commands stay fast. Maps command name ->
+# (module, app attribute, help text shown in --help).
+_LAZY_SUBAPPS: dict[str, tuple[str, str, str]] = {
+    "job": (
+        "domyn_swarm.cli.job",
+        "job_app",
+        "Submit a workload to a Domyn-Swarm allocation.",
+    ),
+    "pool": (
+        "domyn_swarm.cli.pool",
+        "pool_app",
+        "Submit a pool of swarm allocations from a YAML config.",
+    ),
+    "init": (
+        "domyn_swarm.cli.init",
+        "init_app",
+        "Initialize a new Domyn-Swarm configuration.",
+    ),
+    "swarm": (
+        "domyn_swarm.cli.swarm",
+        "swarm_app",
+        "Manage swarm allocations.",
+    ),
+    "db": (
+        "domyn_swarm.cli.db",
+        "db_app",
+        "Manage the Domyn-Swarm state database.",
+    ),
+}
+
+
+class LazyGroup(TyperGroup):
+    """Root group that imports heavy sub-command modules only when invoked.
+
+    Keeps light root commands (version, up, down, status) from importing the
+    job/pool/swarm/db subsystems at startup. ``--help`` and the no-args listing
+    still resolve sub-commands (importing them) so the help output is complete.
+    """
+
+    def list_commands(self, ctx):
+        return sorted(set(super().list_commands(ctx)) | set(_LAZY_SUBAPPS))
+
+    def get_command(self, ctx, cmd_name):
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is not None:
+            return cmd
+        spec = _LAZY_SUBAPPS.get(cmd_name)
+        if spec is None:
+            return None
+        module_path, attr, _ = spec
+        from typer.main import get_command as _typer_to_click
+
+        sub_app = getattr(importlib.import_module(module_path), attr)
+        click_cmd = _typer_to_click(sub_app)
+        self.add_command(click_cmd, cmd_name)
+        return click_cmd
 
 
 class _LazyDomynLLMSwarm:
@@ -90,25 +144,10 @@ class _LazyLogger:
 DomynLLMSwarm = _LazyDomynLLMSwarm()
 SwarmStateManager = _LazySwarmStateManager()
 
-app = typer.Typer(name="domyn-swarm CLI", no_args_is_help=True)
+app = typer.Typer(name="domyn-swarm CLI", no_args_is_help=True, cls=LazyGroup)
 
-app.add_typer(job_app, name="job", help="Submit a workload to a Domyn-Swarm allocation.")
-app.add_typer(
-    pool_app,
-    name="pool",
-    help="Submit a pool of swarm allocations from a YAML config.",
-)
-app.add_typer(
-    init_app,
-    name="init",
-    help="Initialize a new Domyn-Swarm configuration.",
-)
-app.add_typer(swarm_app, name="swarm")
-app.add_typer(
-    db_app,
-    name="db",
-    help="Manage the Domyn-Swarm state database.",
-)
+# Sub-apps (job/pool/init/swarm/db) are registered lazily by LazyGroup; see
+# _LAZY_SUBAPPS above. Only light root commands are wired eagerly below.
 
 logger = _LazyLogger()
 

--- a/src/domyn_swarm/helpers/io.py
+++ b/src/domyn_swarm/helpers/io.py
@@ -13,15 +13,19 @@
 # limitations under the License.
 
 # helpers/io.py
+from __future__ import annotations
+
 import glob
 import math
 import os
 from pathlib import Path
-
-import pandas as pd
+from typing import TYPE_CHECKING
 
 from domyn_swarm import utils
 from domyn_swarm.helpers.patterns import expand_brace_ranges
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def load_dataframe(
@@ -43,6 +47,8 @@ def load_dataframe(
     Returns:
         pd.DataFrame: Loaded dataframe.
     """
+
+    import pandas as pd
 
     read_kwargs = read_kwargs or {}
 

--- a/src/domyn_swarm/utils/imports.py
+++ b/src/domyn_swarm/utils/imports.py
@@ -14,33 +14,46 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 import importlib
 
-_LeptonAPIClient = None  # type: ignore[assignment]
 _LEPTON_IMPORT_ERR: Exception | None = None
 
-# Try modern and fallback module paths (adjust if SDK layout changes)
-for modpath, attr in (
-    ("leptonai.api.v2.client", "APIClient"),
-    ("leptonai.api.client", "APIClient"),  # fallback for older SDKs
-):
-    try:
-        mod = importlib.import_module(modpath)
-        _LeptonAPIClient = getattr(mod, attr)
+
+@lru_cache(maxsize=1)
+def _lepton_client_cls():
+    """Probe for and return the Lepton SDK ``APIClient`` class lazily (cached).
+
+    Returns the class, or ``None`` if the SDK is unavailable (the last import
+    error is recorded in ``_LEPTON_IMPORT_ERR``). The probe runs on first use
+    rather than at module import, so importing this module — and anything that
+    transitively imports it (config, state, CLI) — does NOT pull in leptonai.
+    """
+    global _LEPTON_IMPORT_ERR
+    # Try modern and fallback module paths (adjust if SDK layout changes)
+    for modpath, attr in (
+        ("leptonai.api.v2.client", "APIClient"),
+        ("leptonai.api.client", "APIClient"),  # fallback for older SDKs
+    ):
+        try:
+            mod = importlib.import_module(modpath)
+        except ModuleNotFoundError as e:
+            _LEPTON_IMPORT_ERR = e
+            continue
+        try:
+            cls = getattr(mod, attr)
+        except Exception as e:
+            # Imported module but failed to access symbol (bad install / incompatible deps)
+            _LEPTON_IMPORT_ERR = e
+            break
         _LEPTON_IMPORT_ERR = None
-        break
-    except ModuleNotFoundError as e:
-        _LEPTON_IMPORT_ERR = e
-        continue
-    except Exception as e:
-        # Imported module but failed to access symbol (bad install / incompatible deps)
-        _LEPTON_IMPORT_ERR = e
-        break
+        return cls
+    return None
 
 
 def have_lepton() -> bool:
     """Return True if the Lepton SDK is importable (client class found)."""
-    return _LeptonAPIClient is not None
+    return _lepton_client_cls() is not None
 
 
 def _require_lepton() -> None:
@@ -48,7 +61,7 @@ def _require_lepton() -> None:
     Raise ImportError with a helpful message if the Lepton SDK is unavailable.
     Does NOT instantiate the client; safe to call anywhere.
     """
-    if _LeptonAPIClient is None:
+    if _lepton_client_cls() is None:
         hint = (
             f" (import failed: {type(_LEPTON_IMPORT_ERR).__name__}: {_LEPTON_IMPORT_ERR})"
             if _LEPTON_IMPORT_ERR
@@ -65,14 +78,16 @@ def make_lepton_client(*, token: str | None = None, workspace: str | None = None
     If the SDK requires auth (e.g., `lep login`), pass a token via env/CI.
     """
     _require_lepton()
+    client_cls = _lepton_client_cls()
+    assert client_cls is not None  # _require_lepton would have raised otherwise
     try:
         if token is not None and workspace is not None:
-            return _LeptonAPIClient(token=token, workspace_id=workspace)  # type: ignore[misc]
+            return client_cls(token=token, workspace_id=workspace)
         if token is not None:
-            return _LeptonAPIClient(token=token)  # type: ignore[misc]
+            return client_cls(token=token)
         if workspace is not None:
-            return _LeptonAPIClient(workspace_id=workspace)  # type: ignore[misc]
-        return _LeptonAPIClient()  # type: ignore[misc]
+            return client_cls(workspace_id=workspace)
+        return client_cls()
     except Exception as e:
         raise RuntimeError(
             "Failed to initialize Lepton API client. "

--- a/tests/utils/test_imports.py
+++ b/tests/utils/test_imports.py
@@ -9,7 +9,7 @@ def test_have_lepton_false_when_missing(monkeypatch):
     Args:
         monkeypatch: Pytest monkeypatch fixture.
     """
-    monkeypatch.setattr(imports_mod, "_LeptonAPIClient", None)
+    monkeypatch.setattr(imports_mod, "_lepton_client_cls", lambda: None)
     assert imports_mod.have_lepton() is False
 
 
@@ -19,7 +19,7 @@ def test_require_lepton_raises_import_error(monkeypatch):
     Args:
         monkeypatch: Pytest monkeypatch fixture.
     """
-    monkeypatch.setattr(imports_mod, "_LeptonAPIClient", None)
+    monkeypatch.setattr(imports_mod, "_lepton_client_cls", lambda: None)
     with pytest.raises(ImportError, match="domyn-swarm\\[lepton\\]"):
         imports_mod._require_lepton()
 
@@ -39,7 +39,7 @@ def test_make_lepton_client_uses_overrides(monkeypatch):
         def __init__(self, **kwargs):
             calls.append(kwargs)
 
-    monkeypatch.setattr(imports_mod, "_LeptonAPIClient", DummyClient)
+    monkeypatch.setattr(imports_mod, "_lepton_client_cls", lambda: DummyClient)
     monkeypatch.setattr(imports_mod, "_LEPTON_IMPORT_ERR", None)
 
     client = imports_mod.make_lepton_client(token="tok", workspace="ws")
@@ -60,7 +60,7 @@ def test_make_lepton_client_wraps_errors(monkeypatch):
         def __init__(self, **kwargs):
             raise ValueError("boom")
 
-    monkeypatch.setattr(imports_mod, "_LeptonAPIClient", BoomClient)
+    monkeypatch.setattr(imports_mod, "_lepton_client_cls", lambda: BoomClient)
     monkeypatch.setattr(imports_mod, "_LEPTON_IMPORT_ERR", None)
 
     with pytest.raises(RuntimeError, match="Failed to initialize Lepton API client"):


### PR DESCRIPTION
# What does this PR do?

Speeds up the `domyn-swarm` CLI startup by removing eager imports of heavy
dependencies (pandas, openai, leptonai) from the import path of light commands.
Previously **every** invocation — even `version` or `--help`-less commands —
paid ~6s of import cost because the CLI eagerly imported the whole job/pool/
swarm/db subsystem and probed the Lepton SDK at module load.

### Changes (3 focused commits)
- **`perf(io)`** — `helpers/io.py` imported pandas at module top, so importing the
  trivial `to_path` helper (pulled in via `config.swarm`) dragged in the whole
  pandas stack (~1.2s). Move the import into `load_dataframe` and make the
  `pd.DataFrame` hints lazy via `from __future__ import annotations`.
- **`perf(lepton)`** — `utils/imports.py` probed the Lepton SDK at import time, so
  anything importing `config.lepton` (e.g. `state_manager`, hit by up/down/status)
  paid ~1–1.8s for leptonai at startup. Replace the import-time probe with an
  `lru_cache`d `_lepton_client_cls()` that loads the SDK only when a client is
  actually needed. Tests updated to patch the cached probe.
- **`perf(cli)`** — `cli/main.py` eagerly imported the `job`/`pool`/`swarm`/`db`
  sub-apps for every command. Add a `LazyGroup(TyperGroup)` that imports a
  sub-app only when its subcommand is invoked.

### Results (warm cache)
| Path | Before | After |
|---|---|---|
| `import domyn_swarm.cli.main` | ~5.5–8.9s | **~0.18s** |
| `domyn-swarm version` | ~6s+ | **~0.22s** |
| pandas / openai / leptonai at startup | all loaded | **none loaded** |

Caveat: `domyn-swarm --help` (and the bare no-args listing) still imports the
sub-apps to render their descriptions — making that path lazy would mean
fighting Typer's Rich help renderer, which isn't worth the fragility. Real
command invocations are all fast now.

No behavior changes; subcommands resolve exactly as before. `578 passed,
2 skipped`, ruff + pyright clean.

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/igeniusai/domyn-swarm/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case. → N/A (self-contained startup-perf fix)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/igeniusai/domyn-swarm/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/igeniusai/domyn-swarm/tree/main/docs#writing-source-documentation). → N/A (no docs affected)
- [x] Did you write any new necessary tests? → existing CLI + utils tests cover it

