### PR TITLE
fix(cli): preserve lazy subcommand hierarchy

### DIFF
--- a/src/domyn_swarm/cli/main.py
+++ b/src/domyn_swarm/cli/main.py
@@ -72,11 +72,14 @@ class LazyGroup(TyperGroup):
         spec = _LAZY_SUBAPPS.get(cmd_name)
         if spec is None:
             return None
-        module_path, attr, _ = spec
-        from typer.main import get_command as _typer_to_click
+        module_path, attr, help_text = spec
+        from typer.main import get_group as _typer_to_click_group
 
         sub_app = getattr(importlib.import_module(module_path), attr)
-        click_cmd = _typer_to_click(sub_app)
+        wrapper = typer.Typer()
+        wrapper.add_typer(sub_app, name=cmd_name, help=help_text)
+        click_cmd = _typer_to_click_group(wrapper).get_command(ctx, cmd_name)
+        assert click_cmd is not None
         self.add_command(click_cmd, cmd_name)
         return click_cmd
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -16,6 +16,7 @@ import importlib
 import sys
 from types import SimpleNamespace
 
+from click import unstyle
 import pytest
 from typer.testing import CliRunner
 
@@ -62,6 +63,51 @@ class _FakeStateManager:
     def load(cls, *, deployment_name: str):
         cls._swarm_instance.calls.append(("load", deployment_name))
         return cls._swarm_instance
+
+
+def test_cli_help_lists_lazy_subapps_by_registered_name():
+    expected_commands = {
+        "db": "Manage the Domyn-Swarm state database.",
+        "init": "Initialize a new Domyn-Swarm configuration.",
+        "job": "Submit a workload to a Domyn-Swarm allocation.",
+        "pool": "Submit a pool of swarm allocations from a YAML config.",
+        "swarm": "Manage swarm allocations.",
+    }
+
+    result = runner.invoke(app, ["--help"], terminal_width=160)
+
+    assert result.exit_code == 0
+    output = unstyle(result.output)
+    for command, help_text in expected_commands.items():
+        assert any(f"│ {command}" in line and help_text in line for line in output.splitlines())
+
+
+def test_cli_init_defaults_is_nested():
+    result = runner.invoke(app, ["init", "--help"])
+
+    assert result.exit_code == 0
+    assert any("│ defaults" in line for line in unstyle(result.output).splitlines())
+
+
+def test_cli_init_defaults_dispatches(monkeypatch, tmp_path):
+    import domyn_swarm.cli.init as init_module
+
+    answers = iter([True, False, True])
+    monkeypatch.setattr(init_module, "_yesno", lambda *args, **kwargs: next(answers))
+    monkeypatch.setattr(
+        init_module,
+        "_configure_slurm_defaults",
+        lambda existing: {"slurm": {"image": "img.sif"}},
+    )
+
+    output = tmp_path / "defaults.yaml"
+    result = runner.invoke(
+        app,
+        ["init", "defaults", "--output", str(output), "--force"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output.exists()
 
 
 def test_cli_version(monkeypatch, disable_autoupgrade):


### PR DESCRIPTION
# What does this PR do?

This PR restores the intended Typer subcommand hierarchy when loading CLI sub-apps lazily.

The lazy command resolver previously converted each sub-app directly into a Click command. This caused single-command applications to be flattened and multi-command groups to lose their registered names and parent help text.

As a result:

- `defaults` appeared as a top-level command instead of `init`.
- `db`, `job`, and `swarm` appeared without visible command names.
- `ds init` invoked the defaults wizard directly.
- `ds init defaults` was rejected as an unexpected argument.
- Help descriptions came from the child applications instead of the root lazy-subcommand registry.

The lazy resolver now registers each imported application through Typer's standard `add_typer` conversion. This preserves the parent command name, help text, and nested command structure without making imports eager.

The resulting hierarchy is:

```text
ds init
└── defaults
```

The root help now consistently lists `db`, `init`, `job`, `pool`, and `swarm`.

No new dependencies are introduced.

### Validation

- `544 passed, 2 skipped`
- All CLI tests pass.
- Ruff checks and formatting pass.
- Pyright reports no errors or warnings.
- Regression tests cover:
  - lazy subcommand names and descriptions in root help;
  - `defaults` appearing under `ds init`;
  - dispatching the defaults wizard through `ds init defaults`.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [[contributor guideline](https://github.com/igeniusai/domyn-swarm/blob/main/CONTRIBUTING.md)](https://github.com/igeniusai/domyn-swarm/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? No documentation update is required because this corrects generated CLI help and routing.
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.