### PR TITLE
refactor(watchdog): align the runtime config with the YAML schema

### DIFF
--- a/src/domyn_swarm/runtime/watchdog.py
+++ b/src/domyn_swarm/runtime/watchdog.py
@@ -85,30 +85,42 @@ class WatchdogRayConfig:
     expected_workers: int | None = None  # None => don't gate on worker count
     probe_timeout_s: float = 120.0
     status_grace_s: float = 10.0
-    probe_interval_s: float = 10.0  # how often to check Ray once child is running
+    probe_interval_s: float = 30.0  # how often to check Ray once child is running
 
 
 @dataclass
 class WatchdogConfig:
+    """Runtime mirror of `domyn_swarm.config.watchdog.WatchdogConfig`.
+
+    Kept as a separate stdlib dataclass because this module runs inside the vLLM
+    container, where neither pydantic nor `domyn_swarm` is importable. Field names
+    and defaults must stay identical to the YAML schema so an option that fails to
+    reach the process falls back to the documented value --
+    `tests/runtime/test_watchdog_config_parity.py` enforces that.
+
+    `host`, `port`, `agent_version` and `unhealthy_http_failures` have no YAML
+    counterpart: they are injected per replica at launch.
+    """
+
     # HTTP health
     host: str = "127.0.0.1"
     port: int = 8000
-    http_path: str = "/v1/health"
-    http_timeout_s: float = 2.0
-    probe_interval_s: float = 10.0
+    http_path: str = "/health"
+    http_timeout: float = 2.0
+    probe_interval: float = 30.0
     unhealthy_http_failures: int = 3
     # How long to allow UNHEALTHY before forcing a restart.
-    unhealthy_restart_after: float = 300.0
+    unhealthy_restart_after: float = 120.0
 
     kill_grace_seconds: float = 10.0
 
     # Restart
     restart_policy: str = "on-failure"  # "always" | "on-failure" | "never"
-    restart_backoff_s: float = 10.0
-    restart_backoff_max_s: float = 60.0  # ceiling for the exponential backoff
-    max_restarts: int | None = None  # None => unlimited
+    restart_backoff_initial: float = 5.0
+    restart_backoff_max: float = 60.0  # ceiling for the exponential backoff
+    max_restarts: int | None = 3
 
-    readiness_timeout: float = 60.0  # seconds to wait for initial readiness
+    readiness_timeout: float = 600.0  # seconds to wait for initial readiness
 
     # Metadata
     agent_version: str = "unknown"
@@ -503,8 +515,8 @@ def _spawn_child_and_mark_running(
 def _restart_backoff_delay(cfg: WatchdogConfig, attempt: int) -> float:
     """Return the seconds to wait before restart attempt ``attempt``.
 
-    Grows exponentially from ``restart_backoff_s`` and is capped at
-    ``restart_backoff_max_s`` so a replica that keeps dying does not hammer the
+    Grows exponentially from ``restart_backoff_initial`` and is capped at
+    ``restart_backoff_max`` so a replica that keeps dying does not hammer the
     scheduler at a fixed rate.
 
     Args:
@@ -512,10 +524,10 @@ def _restart_backoff_delay(cfg: WatchdogConfig, attempt: int) -> float:
         attempt: 1-based restart attempt number.
 
     Returns:
-        Delay in seconds, never above ``cfg.restart_backoff_max_s``.
+        Delay in seconds, never above ``cfg.restart_backoff_max``.
     """
-    delay = cfg.restart_backoff_s * (2 ** max(0, attempt - 1))
-    return min(delay, cfg.restart_backoff_max_s)
+    delay = cfg.restart_backoff_initial * (2 ** max(0, attempt - 1))
+    return min(delay, cfg.restart_backoff_max)
 
 
 def _should_restart(exit_code: int, cfg: WatchdogConfig, restart_count: int) -> bool:
@@ -544,7 +556,7 @@ def _probe_and_update(
     url = cfg.http_url()
 
     # HTTP probe
-    http_ok = _check_http(url, cfg.http_timeout_s)
+    http_ok = _check_http(url, cfg.http_timeout)
     if http_ok:
         http_failures = 0
         http_ok_since = http_ok_since or now
@@ -790,7 +802,7 @@ def _monitor_child_loop(
                     )
                     return ret, should_restart, fail_reason
 
-        time.sleep(cfg.probe_interval_s)
+        time.sleep(cfg.probe_interval)
 
 
 def run_watchdog(
@@ -1088,13 +1100,13 @@ def main(argv: list[str] | None = None) -> int:
         host="127.0.0.1",  # typically localhost inside the replica node
         port=args.port,
         http_path=_ensure_leading_slash(args.http_path),
-        http_timeout_s=args.http_timeout,
-        probe_interval_s=args.probe_interval,
+        http_timeout=args.http_timeout,
+        probe_interval=args.probe_interval,
         unhealthy_http_failures=args.unhealthy_http_failures,
         unhealthy_restart_after=args.unhealthy_restart_after,
         restart_policy=args.restart_policy,
-        restart_backoff_s=args.restart_backoff,
-        restart_backoff_max_s=args.restart_backoff_max,
+        restart_backoff_initial=args.restart_backoff,
+        restart_backoff_max=args.restart_backoff_max,
         kill_grace_seconds=args.kill_grace_seconds,
         max_restarts=args.max_restarts,
         agent_version=args.agent_version,

--- a/tests/runtime/test_watchdog_config_parity.py
+++ b/tests/runtime/test_watchdog_config_parity.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+"""The YAML schema and the in-container runtime config must agree.
+
+`runtime/watchdog.py` is bind-mounted into the vLLM container and run by that
+container's interpreter, so it cannot import pydantic or anything from
+`domyn_swarm` -- the two definitions genuinely have to be separate classes.
+
+What must not differ is what they *say*: a field means the same thing under the
+same name, and an option that fails to reach the process falls back to the value
+the YAML schema advertises rather than a different one. These tests are the only
+thing holding that line, so they enumerate the exceptions explicitly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from domyn_swarm.config.watchdog import (
+    WatchdogConfig as YamlConfig,
+    WatchdogRayConfig as YamlRayConfig,
+)
+from domyn_swarm.runtime.watchdog import (
+    WatchdogConfig as RuntimeConfig,
+    WatchdogRayConfig as RuntimeRayConfig,
+)
+
+# Declared in the YAML schema but deliberately absent from the runtime dataclass.
+YAML_ONLY = {
+    "enabled",  # gates whether the sbatch template launches the watchdog at all
+    "ray",  # the nested model; compared separately
+}
+
+# Present only in the runtime dataclass: values injected per replica at launch,
+# not user-configurable through YAML.
+RUNTIME_ONLY = {
+    "host",
+    "port",
+    "agent_version",
+    "unhealthy_http_failures",
+}
+
+RUNTIME_ONLY_RAY = {
+    "expected_workers",  # derived from SLURM_JOB_NUM_NODES, not from YAML
+}
+
+
+def _runtime_defaults(dc) -> dict:
+    return {
+        f.name: f.default for f in dataclasses.fields(dc) if f.default is not dataclasses.MISSING
+    }
+
+
+def _yaml_defaults(model) -> dict:
+    return {name: field.default for name, field in model.model_fields.items()}
+
+
+@pytest.mark.parametrize(
+    ("yaml_model", "runtime_dc", "yaml_only", "runtime_only"),
+    [
+        (YamlConfig, RuntimeConfig, YAML_ONLY, RUNTIME_ONLY),
+        (YamlRayConfig, RuntimeRayConfig, set(), RUNTIME_ONLY_RAY),
+    ],
+    ids=["WatchdogConfig", "WatchdogRayConfig"],
+)
+def test_field_names_match(yaml_model, runtime_dc, yaml_only, runtime_only):
+    """A setting is spelled the same on both sides of the process boundary."""
+    yaml_names = set(_yaml_defaults(yaml_model)) - yaml_only
+    runtime_names = set(_runtime_defaults(runtime_dc)) - runtime_only
+
+    missing_in_runtime = sorted(yaml_names - runtime_names)
+    missing_in_yaml = sorted(runtime_names - yaml_names)
+
+    assert not missing_in_runtime, (
+        f"YAML fields with no runtime counterpart: {missing_in_runtime}. "
+        f"Either add them, or list them in YAML_ONLY with a reason."
+    )
+    assert not missing_in_yaml, (
+        f"Runtime fields with no YAML counterpart: {missing_in_yaml}. "
+        f"Either add them, or list them in RUNTIME_ONLY with a reason."
+    )
+
+
+@pytest.mark.parametrize(
+    ("yaml_model", "runtime_dc", "yaml_only"),
+    [
+        (YamlConfig, RuntimeConfig, YAML_ONLY),
+        (YamlRayConfig, RuntimeRayConfig, set()),
+    ],
+    ids=["WatchdogConfig", "WatchdogRayConfig"],
+)
+def test_defaults_match(yaml_model, runtime_dc, yaml_only):
+    """An option that fails to reach the process falls back to the documented value."""
+    yaml_defaults = _yaml_defaults(yaml_model)
+    runtime_defaults = _runtime_defaults(runtime_dc)
+
+    mismatched = {
+        name: (value, runtime_defaults[name])
+        for name, value in yaml_defaults.items()
+        if name not in yaml_only and name in runtime_defaults and value != runtime_defaults[name]
+    }
+
+    assert not mismatched, (
+        "Same field, different default (yaml, runtime): "
+        f"{mismatched}. A field that is not forwarded would silently behave "
+        f"differently from what the YAML schema documents."
+    )
+
+
+# The argparse layer is what actually governs when a flag is omitted, so it has to
+# agree with the YAML schema too. Maps argparse dest -> YAML field name.
+ARGV_TO_YAML = {
+    "http_path": "http_path",
+    "http_timeout": "http_timeout",
+    "probe_interval": "probe_interval",
+    "readiness_timeout": "readiness_timeout",
+    "unhealthy_restart_after": "unhealthy_restart_after",
+    "restart_policy": "restart_policy",
+    "restart_backoff": "restart_backoff_initial",
+    "restart_backoff_max": "restart_backoff_max",
+    "kill_grace_seconds": "kill_grace_seconds",
+    "max_restarts": "max_restarts",
+    "log_level": "log_level",
+}
+
+ARGV_TO_YAML_RAY = {
+    "ray_timeout": "probe_timeout_s",
+    "ray_grace": "status_grace_s",
+    "ray_probe_interval": "probe_interval_s",
+}
+
+_MINIMAL_ARGV = [
+    "--swarm-id",
+    "s",
+    "--replica-id",
+    "0",
+    "--node",
+    "n",
+    "--port",
+    "8000",
+    "--log-dir",
+    "/tmp",
+    "--collector-address",
+    "127.0.0.1:9100",
+]
+
+
+@pytest.mark.parametrize(
+    ("mapping", "yaml_model"),
+    [(ARGV_TO_YAML, YamlConfig), (ARGV_TO_YAML_RAY, YamlRayConfig)],
+    ids=["WatchdogConfig", "WatchdogRayConfig"],
+)
+def test_argparse_defaults_match_the_yaml_schema(mapping, yaml_model):
+    """Omitting a flag must land on the value the YAML schema documents."""
+    from domyn_swarm.runtime.watchdog import _parse_args
+
+    args = _parse_args(list(_MINIMAL_ARGV))
+    yaml_defaults = _yaml_defaults(yaml_model)
+
+    mismatched = {
+        dest: (getattr(args, dest), yaml_defaults[yaml_name])
+        for dest, yaml_name in mapping.items()
+        if getattr(args, dest) != yaml_defaults[yaml_name]
+    }
+
+    assert not mismatched, (
+        f"argparse default differs from the YAML default (argv, yaml): {mismatched}"
+    )
+
+
+def test_every_yaml_field_is_covered_by_one_of_these_checks():
+    """A new YAML field cannot be added without deciding how it reaches the process."""
+    covered = set(ARGV_TO_YAML.values()) | YAML_ONLY
+    uncovered = sorted(set(YamlConfig.model_fields) - covered)
+
+    assert not uncovered, (
+        f"WatchdogConfig fields not mapped to a watchdog argument: {uncovered}. "
+        f"Add them to ARGV_TO_YAML, or to YAML_ONLY with a reason."
+    )

--- a/tests/runtime/test_watchdog_helpers.py
+++ b/tests/runtime/test_watchdog_helpers.py
@@ -94,7 +94,7 @@ def test_probe_and_update_marks_running(monkeypatch):
 
 def test_restart_backoff_grows_exponentially():
     """Repeated restarts back off instead of hammering the scheduler at a fixed rate."""
-    cfg = watchdog_mod.WatchdogConfig(restart_backoff_s=5.0, restart_backoff_max_s=60.0)
+    cfg = watchdog_mod.WatchdogConfig(restart_backoff_initial=5.0, restart_backoff_max=60.0)
 
     delays = [watchdog_mod._restart_backoff_delay(cfg, attempt) for attempt in range(1, 5)]
 
@@ -103,7 +103,7 @@ def test_restart_backoff_grows_exponentially():
 
 def test_restart_backoff_is_capped_by_the_configured_ceiling():
     """`restart_backoff_max` is the documented upper bound, so it must bind."""
-    cfg = watchdog_mod.WatchdogConfig(restart_backoff_s=5.0, restart_backoff_max_s=30.0)
+    cfg = watchdog_mod.WatchdogConfig(restart_backoff_initial=5.0, restart_backoff_max=30.0)
 
     delays = [watchdog_mod._restart_backoff_delay(cfg, attempt) for attempt in range(1, 6)]
 


### PR DESCRIPTION
# Align the runtime watchdog config with the YAML schema

`config/watchdog.py` (pydantic, read from YAML) and `runtime/watchdog.py`
(dataclass, built from argv) both define `WatchdogConfig` and `WatchdogRayConfig`.
Fields were spelled differently across the process boundary, and six shared
defaults disagreed — so a setting that failed to reach the watchdog fell back to a
different value than the one the YAML schema documents:

| Field | YAML says | Runtime used |
| --- | --- | --- |
| `http_path` | `/health` | `/v1/health` |
| `probe_interval` | `30` | `10` |
| `readiness_timeout` | `600` | `60` |
| `unhealthy_restart_after` | `120` | `300` |
| `max_restarts` | `3` | `None` (unlimited) |
| `ray.probe_interval_s` | `30.0` | `10.0` |

This is the companion to the inert-knobs fix (#150): forwarding the fields stopped
them being ignored, but nothing stopped the two definitions drifting again.

### Why they aren't merged into one class

`runtime/watchdog.py` is bind-mounted as a single file into the vLLM container and
run by *that* container's interpreter:

```
MOUNTS="...,{{ watchdog_script_path }}:/opt/watchdog.py"
python3 /opt/watchdog.py <args> -- vllm serve ...
```

It can import neither pydantic nor anything from `domyn_swarm`, and it holds to
that today — 18 imports, all standard library. So the two classes genuinely have to
stay separate.

What they can share is a single set of names and values, held by a test rather than
by an import.

### What changes

Runtime fields renamed to their YAML spellings, so a setting reads the same on both
sides:

```
http_timeout_s        -> http_timeout
probe_interval_s      -> probe_interval
restart_backoff_s     -> restart_backoff_initial
restart_backoff_max_s -> restart_backoff_max
```

…and every shared default aligned. All 12 shared fields now agree.

`tests/runtime/test_watchdog_config_parity.py` pins **all three** default layers —
the YAML schema, the argparse defaults, and the runtime dataclass — to the same
names and values. Fields that are legitimately one-sided are listed explicitly with
a reason rather than silently tolerated:

- `enabled` is YAML-only: it gates whether the sbatch template launches the watchdog
  at all, so the process never sees it.
- `host`, `port`, `agent_version`, `unhealthy_http_failures` are runtime-only:
  injected per replica at launch.
- `ray.expected_workers` is runtime-only: derived from `SLURM_JOB_NUM_NODES`.

A final test asserts every YAML field is covered by one of those categories, so a
new field cannot be added without deciding how it reaches the process.

### Verification

- 991 tests pass, 2 skipped
- `ruff check` clean, `pyright` clean, `pre-commit run --all-files` clean
- Each parity assertion was verified to **fail** when its corresponding default is
  perturbed — on the argparse side and the YAML side independently. These tests pass
  on first run because they lock in behaviour that is already correct after the
  alignment, so proving they can fail was the only way to know they work.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/igeniusai/domyn-swarm/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/igeniusai/domyn-swarm/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/igeniusai/domyn-swarm/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
