### PR TITLE
Refactor/decouple swarm internals

### DIFF
--- a/src/domyn_swarm/backends/compute/lepton.py
+++ b/src/domyn_swarm/backends/compute/lepton.py
@@ -10,8 +10,6 @@ from domyn_swarm.config.settings import get_settings
 from domyn_swarm.platform.protocols import DefaultComputeMixin, JobHandle, JobProbe, JobStatus
 from domyn_swarm.utils.imports import _require_lepton, make_lepton_client
 
-settings = get_settings()
-
 
 @dataclass
 class LeptonComputeBackend(DefaultComputeMixin):  # type: ignore[misc]
@@ -39,9 +37,8 @@ class LeptonComputeBackend(DefaultComputeMixin):  # type: ignore[misc]
     def _client(self):
         if self._client_cached is None:
             _require_lepton()  # quick availability check
-            token = (
-                settings.lepton_api_token.get_secret_value() if settings.lepton_api_token else None
-            )
+            lepton_api_token = get_settings().lepton_api_token
+            token = lepton_api_token.get_secret_value() if lepton_api_token else None
             self._client_cached = make_lepton_client(
                 token=token,
                 workspace=getattr(self, "workspace", None),

--- a/src/domyn_swarm/backends/serving/lepton.py
+++ b/src/domyn_swarm/backends/serving/lepton.py
@@ -27,8 +27,6 @@ if TYPE_CHECKING:
 
 logger = setup_logger(__name__, level=logging.INFO)
 
-settings = get_settings()
-
 
 @dataclass
 class LeptonServingBackend(ServingBackend):  # type: ignore[misc]
@@ -65,9 +63,8 @@ class LeptonServingBackend(ServingBackend):  # type: ignore[misc]
     def _client(self) -> "APIClient":
         if self._client_cached is None:
             _require_lepton()  # quick availability check
-            token = (
-                settings.lepton_api_token.get_secret_value() if settings.lepton_api_token else None
-            )
+            lepton_api_token = get_settings().lepton_api_token
+            token = lepton_api_token.get_secret_value() if lepton_api_token else None
             self._client_cached = make_lepton_client(
                 token=token,
                 workspace=getattr(self, "workspace", None),

--- a/src/domyn_swarm/backends/serving/slurm.py
+++ b/src/domyn_swarm/backends/serving/slurm.py
@@ -24,8 +24,6 @@ from domyn_swarm.platform.protocols import (
     ServingStatus,
 )
 
-settings = get_settings()
-
 
 @dataclass
 class SlurmServingBackend(ServingBackend):  # type: ignore[misc]
@@ -47,6 +45,7 @@ class SlurmServingBackend(ServingBackend):  # type: ignore[misc]
     readiness: SlurmReadiness | None = None
 
     def create_or_update(self, name: str, spec: dict, extras: dict) -> ServingHandle:
+        settings = get_settings()
         replicas = spec.get("replicas", 1)
         nodes = spec.get("nodes", 1)
         gpus_per_node = spec.get("gpus_per_node", 1)
@@ -141,9 +140,7 @@ class SlurmServingBackend(ServingBackend):  # type: ignore[misc]
             handle.meta["lb_jobid"]
         )
         base = f"http://{lb_node}:{self.cfg.endpoint.port}"
-        api_token = (
-            settings.api_token or settings.vllm_api_key or settings.singularityenv_vllm_api_key
-        )
+        api_token = get_settings().resolved_api_token
         try:
             if api_token:
                 headers = {"Authorization": f"Bearer {api_token.get_secret_value()}"}

--- a/src/domyn_swarm/cli/db.py
+++ b/src/domyn_swarm/cli/db.py
@@ -105,7 +105,7 @@ def db_prune(
             continue
         try:
             swarm = DomynLLMSwarm.from_state(deployment_name=deployment_name)
-            st = swarm._deployment.serving.status(swarm.serving_handle)  # type: ignore[attr-defined]
+            st = swarm.serving_status()
         except Exception as e:
             logger.debug(f"Status probe failed for {deployment_name}: {e}")
             to_be_deleted.append(deployment_name)

--- a/src/domyn_swarm/cli/main.py
+++ b/src/domyn_swarm/cli/main.py
@@ -334,7 +334,7 @@ def check_status(
     render_status(
         (
             name,
-            swarm._platform,
+            swarm.platform,
             serving_status or ServingStatus(phase=ServingPhase.UNKNOWN, url=swarm.endpoint),
         ),
         replica_summary=replica_summary,
@@ -418,7 +418,7 @@ def _build_status_json(
         )
         started_at_iso = started_at.isoformat()
 
-        if swarm._platform == "slurm":
+        if swarm.platform == "slurm":
             from ..helpers.slurm import parse_slurm_time_limit
 
             time_limit = getattr(swarm.cfg.backend, "time_limit", None)
@@ -427,7 +427,7 @@ def _build_status_json(
                 expires_at_iso = (started_at + delta).isoformat()
 
     slurm_jobs: list[dict] | None = None
-    if swarm._platform == "slurm" and swarm.serving_handle is not None:
+    if swarm.platform == "slurm" and swarm.serving_handle is not None:
         meta = swarm.serving_handle.meta or {}
         jobs: list[dict] = []
         if meta.get("jobid") is not None:
@@ -445,7 +445,7 @@ def _build_status_json(
     payload: dict = {
         "schema_version": 1,
         "name": name,
-        "backend": swarm._platform,
+        "backend": swarm.platform,
         "phase": phase,
         "state": phase,
         "ready": ready,

--- a/src/domyn_swarm/cli/monitor.py
+++ b/src/domyn_swarm/cli/monitor.py
@@ -15,7 +15,7 @@ from importlib import resources
 import os
 from pathlib import Path
 import shutil
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 
@@ -190,10 +190,10 @@ def monitor(
     """Launch grafatui pointed at the swarm's Prometheus endpoint."""
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
-    # Lightweight read: just endpoint + cfg, without building the deployment plan
-    # (which would import the whole serving backend that monitoring never uses).
-    swarm: Any = SwarmStateManager.load_monitor_view(deployment_name=name)
-    mon = getattr(swarm.cfg.backend.endpoint, "monitoring", None)
+    swarm = SwarmStateManager.load(deployment_name=name)
+    backend = swarm.cfg.backend
+    assert backend is not None, "Loaded swarm has no backend configuration"
+    mon = getattr(backend.endpoint, "monitoring", None)
     if not getattr(mon, "enabled", False):
         typer.echo(
             f"Monitoring is not enabled for swarm '{name}'. "

--- a/src/domyn_swarm/cli/swarm.py
+++ b/src/domyn_swarm/cli/swarm.py
@@ -154,7 +154,7 @@ def describe_swarm(
     # Load a single record from state
     swarm = SwarmStateManager.load(deployment_name=name)
 
-    backend = swarm._platform.lower()
+    backend = swarm.platform.lower()
     endpoint = swarm.endpoint or ""
     cfg = swarm.cfg
     data = cfg.model_dump(mode="json", by_alias=True, exclude_none=True)

--- a/src/domyn_swarm/cli/swarm.py
+++ b/src/domyn_swarm/cli/swarm.py
@@ -91,8 +91,7 @@ def _iter_summaries(*, probe: bool) -> Iterable[SwarmSummary]:
             try:
                 # Load a live swarm and ask the serving backend for status
                 swarm = DomynLLMSwarm.from_state(deployment_name=deployment_name)
-                # Prefer serving.status(handle) if present
-                st = swarm._deployment.serving.status(swarm.serving_handle)  # type: ignore[attr-defined]
+                st = swarm.serving_status()
                 if st.phase in hidden_phases:
                     continue  # skip dirty swarms
                 phase = st.phase.value

--- a/src/domyn_swarm/config/plan.py
+++ b/src/domyn_swarm/config/plan.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: 2025-2026 Domyn
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any
 
-from domyn_swarm.platform.protocols import ComputeBackend, ServingBackend
+from domyn_swarm.platform.protocols import ComputeBackend, ServingBackend, ServingHandle
 
 
 @dataclass
@@ -21,21 +22,50 @@ class DeploymentContext:
 
 @dataclass
 class DeploymentPlan:
-    """
-    Fully constructed pair (serving, compute) plus per-backend specs
-    that the app will use when calling Deployment.up()/run().
+    """A fully constructed (serving, compute) pair plus per-backend specs.
+
+    Attributes:
+        compute: The compute backend, when it can be built without a live
+            serving endpoint. ``None`` for platforms whose compute backend
+            depends on the handle (Slurm needs ``lb_jobid``/``lb_node``).
+        compute_factory: Builds the compute backend from a ready
+            :class:`ServingHandle`. Takes precedence over ``compute``.
+        platform: Platform identifier, matching ``cfg.backend.type``.
     """
 
-    name_hint: str  # optional suffix/prefix for generated names
+    name_hint: str
     serving: ServingBackend
-    compute: ComputeBackend
-    serving_spec: dict  # pass to DeploymentContext for Deployment.up(...)
-    job_resources: dict  # optional: pass/merge when running jobs
-    extras: dict  # any useful extras (e.g., workspace id)
+    compute: ComputeBackend | None
+    serving_spec: dict
+    job_resources: dict
+    extras: dict
     shared_env: dict[str, str] = field(default_factory=dict)
     image: str | None = None
     timeout_s: int | None = None
-    platform: Literal["lepton", "slurm"] = "slurm"
+    platform: str = "slurm"
+    compute_factory: Callable[[ServingHandle], ComputeBackend] | None = None
+
+    def make_compute_backend(self, handle: ServingHandle) -> ComputeBackend:
+        """Return the compute backend for a ready serving endpoint.
+
+        Args:
+            handle: The handle returned once the serving endpoint is ready.
+
+        Returns:
+            The compute backend to submit jobs against this endpoint.
+
+        Raises:
+            RuntimeError: If the platform supplies neither a factory nor a
+                plan-time compute backend.
+        """
+        if self.compute_factory is not None:
+            return self.compute_factory(handle)
+        if self.compute is not None:
+            return self.compute
+        raise RuntimeError(
+            f"Platform {self.platform!r} supplies no compute backend: its build() "
+            "must set either `compute` or `compute_factory`."
+        )
 
 
 class PlanBuilder:

--- a/src/domyn_swarm/config/plan.py
+++ b/src/domyn_swarm/config/plan.py
@@ -31,6 +31,9 @@ class DeploymentPlan:
         compute_factory: Builds the compute backend from a ready
             :class:`ServingHandle`. Takes precedence over ``compute``.
         platform: Platform identifier, matching ``cfg.backend.type``.
+        handle_validator: Checks that a handle carries everything this
+            platform's backends need. ``None`` means the platform imposes no
+            requirements beyond what the backends themselves check.
     """
 
     name_hint: str
@@ -44,6 +47,25 @@ class DeploymentPlan:
     timeout_s: int | None = None
     platform: str = "slurm"
     compute_factory: Callable[[ServingHandle], ComputeBackend] | None = None
+    handle_validator: Callable[[ServingHandle], None] | None = None
+
+    def validate_serving_handle(self, handle: ServingHandle) -> None:
+        """Check that a serving handle is usable by this platform's backends.
+
+        Called when adopting a handle that was not produced in this process --
+        typically one rehydrated from the state DB -- so an incomplete record
+        fails with a clear message instead of a stray ``KeyError`` from inside
+        a backend later on. Platforms without extra requirements supply no
+        validator and everything passes.
+
+        Args:
+            handle: The handle about to be adopted.
+
+        Raises:
+            ValueError: If the handle is missing metadata this platform needs.
+        """
+        if self.handle_validator is not None:
+            self.handle_validator(handle)
 
     def make_compute_backend(self, handle: ServingHandle) -> ComputeBackend:
         """Return the compute backend for a ready serving endpoint.

--- a/src/domyn_swarm/config/settings.py
+++ b/src/domyn_swarm/config/settings.py
@@ -56,6 +56,16 @@ class Settings(BaseSettings):
         description="Alternative env var for API token, used inside Singularity containers",
     )
 
+    @property
+    def resolved_api_token(self) -> SecretStr | None:
+        """Return the first configured LLM API token, in precedence order.
+
+        Returns:
+            ``api_token`` if set, else ``vllm_api_key``, else
+            ``singularityenv_vllm_api_key``, else ``None``.
+        """
+        return self.api_token or self.vllm_api_key or self.singularityenv_vllm_api_key
+
     # --- Slurm ---------------------------------------------------------------
     mail_user: str | None = Field(
         description="Email address for Slurm job notifications (if enabled)",

--- a/src/domyn_swarm/config/slurm.py
+++ b/src/domyn_swarm/config/slurm.py
@@ -454,6 +454,17 @@ class SlurmConfig(BaseModel):
                 )
             return SlurmComputeBackend(cfg=self, lb_jobid=lb_jobid, lb_node=lb_node)
 
+        def _validate_handle(handle: ServingHandle) -> None:
+            """Reject a handle the Slurm serving backend could not query.
+
+            ``SlurmServingBackend.status()`` subscripts ``meta["jobid"]``
+            directly, so a handle without one -- a state record written before
+            the replica job existed, say -- would blow up with a bare KeyError
+            deep inside ``status()`` instead of here.
+            """
+            if handle.meta.get("jobid") is None:
+                raise ValueError("State file does not contain valid job IDs")
+
         serving_spec = self.model_dump(exclude_none=True) | cfg_ctx.model_dump(
             include={
                 "replicas",
@@ -470,6 +481,7 @@ class SlurmConfig(BaseModel):
             serving=serving,
             compute=None,
             compute_factory=_make_compute,
+            handle_validator=_validate_handle,
             serving_spec=serving_spec,
             job_resources={},
             extras={},

--- a/src/domyn_swarm/config/slurm.py
+++ b/src/domyn_swarm/config/slurm.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from domyn_swarm import utils
 from domyn_swarm.config.defaults import default_for
 from domyn_swarm.config.plan import DeploymentPlan
+from domyn_swarm.platform.protocols import ServingHandle
 
 _DCGM_DEFAULT_IMAGE = "nvcr.io/nvidia/k8s/dcgm-exporter:3.3.5-3.4.1-ubuntu22.04"
 
@@ -440,7 +441,18 @@ class SlurmConfig(BaseModel):
 
         driver = SlurmDriver(cfg=cfg_ctx)
         serving = SlurmServingBackend(cfg=self, driver=driver)
-        compute = SlurmComputeBackend(cfg=self, lb_jobid=0, lb_node="")
+
+        def _make_compute(handle: ServingHandle) -> SlurmComputeBackend:
+            """Build the Slurm compute backend from a ready serving handle."""
+            lb_jobid = handle.meta.get("lb_jobid")
+            lb_node = handle.meta.get("lb_node")
+            if not lb_jobid or not lb_node:
+                raise RuntimeError(
+                    "Slurm serving handle is missing load-balancer metadata "
+                    f"(lb_jobid={lb_jobid!r}, lb_node={lb_node!r}); the endpoint "
+                    "is not ready."
+                )
+            return SlurmComputeBackend(cfg=self, lb_jobid=lb_jobid, lb_node=lb_node)
 
         serving_spec = self.model_dump(exclude_none=True) | cfg_ctx.model_dump(
             include={
@@ -456,7 +468,8 @@ class SlurmConfig(BaseModel):
         return DeploymentPlan(
             name_hint="slurm",
             serving=serving,
-            compute=compute,
+            compute=None,
+            compute_factory=_make_compute,
             serving_spec=serving_spec,
             job_resources={},
             extras={},

--- a/src/domyn_swarm/config/slurm.py
+++ b/src/domyn_swarm/config/slurm.py
@@ -8,10 +8,6 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from domyn_swarm import utils
 from domyn_swarm.config.defaults import default_for
 from domyn_swarm.config.plan import DeploymentPlan
-from domyn_swarm.config.settings import get_settings
-
-settings = get_settings()
-
 
 _DCGM_DEFAULT_IMAGE = "nvcr.io/nvidia/k8s/dcgm-exporter:3.3.5-3.4.1-ubuntu22.04"
 

--- a/src/domyn_swarm/core/state/state_manager.py
+++ b/src/domyn_swarm/core/state/state_manager.py
@@ -107,6 +107,12 @@ class SwarmStateManager:
         swarm._deployment._handle = serving_handle
 
         assert swarm._plan is not None
+        if swarm._plan.platform == "slurm" and serving_handle.meta.get("jobid") is None:
+            # The compute backend itself only needs lb_jobid/lb_node, but the
+            # Slurm serving backend later indexes handle.meta["jobid"]
+            # directly (see backends/serving/slurm.py). Fail loudly here,
+            # at load time, rather than with a bare KeyError deep in status().
+            raise ValueError("State file does not contain valid job IDs")
         swarm._deployment.compute = swarm._plan.make_compute_backend(serving_handle)
         return swarm
 

--- a/src/domyn_swarm/core/state/state_manager.py
+++ b/src/domyn_swarm/core/state/state_manager.py
@@ -9,16 +9,12 @@ from typing import TYPE_CHECKING, Any
 
 from ulid import ULID
 
-from domyn_swarm.config.lepton import LeptonConfig
 from domyn_swarm.config.settings import get_settings
-from domyn_swarm.config.slurm import SlurmConfig
 from domyn_swarm.exceptions import JobNotFoundError
 from domyn_swarm.helpers.logger import setup_logger
 from domyn_swarm.platform.protocols import JobStatus, ServingHandle
 
 if TYPE_CHECKING:
-    from domyn_swarm.backends.compute.slurm import SlurmComputeBackend
-
     from ..swarm import DomynLLMSwarm
 
 from .db import make_session_factory
@@ -110,22 +106,8 @@ class SwarmStateManager:
         swarm.serving_handle = serving_handle
         swarm._deployment._handle = serving_handle
 
-        platform = swarm._platform
-        if platform == "slurm":
-            backend = cls._get_slurm_backend(
-                handle=swarm.serving_handle, slurm_cfg=swarm.cfg.backend
-            )
-        elif platform == "lepton":
-            from domyn_swarm.backends.compute.lepton import LeptonComputeBackend
-
-            assert isinstance(swarm.cfg.backend, LeptonConfig)
-            backend = LeptonComputeBackend(
-                workspace=swarm.cfg.backend.workspace_id
-            )  # adjust as needed
-        else:
-            raise ValueError(f"Unsupported platform: {platform}")
-
-        swarm._deployment.compute = backend
+        assert swarm._plan is not None
+        swarm._deployment.compute = swarm._plan.make_compute_backend(serving_handle)
         return swarm
 
     @classmethod
@@ -203,20 +185,6 @@ class SwarmStateManager:
             }
             for r in rows
         ]
-
-    @classmethod
-    def _get_slurm_backend(cls, handle, slurm_cfg) -> "SlurmComputeBackend":
-        from domyn_swarm.backends.compute.slurm import SlurmComputeBackend
-
-        jobid = handle.meta.get("jobid")
-        lb_jobid = handle.meta.get("lb_jobid")
-        lb_node = handle.meta.get("lb_node")
-        if jobid is None:
-            raise ValueError("State file does not contain valid job IDs")
-        if lb_jobid is None or lb_node is None:
-            raise ValueError("State file does not contain valid LB job info")
-        assert isinstance(slurm_cfg, SlurmConfig)
-        return SlurmComputeBackend(cfg=slurm_cfg, lb_jobid=lb_jobid, lb_node=lb_node)
 
     @classmethod
     def get_creation_dt(cls, deployment_name: str) -> datetime | None:

--- a/src/domyn_swarm/core/state/state_manager.py
+++ b/src/domyn_swarm/core/state/state_manager.py
@@ -12,7 +12,7 @@ from ulid import ULID
 from domyn_swarm.config.settings import get_settings
 from domyn_swarm.exceptions import JobNotFoundError
 from domyn_swarm.helpers.logger import setup_logger
-from domyn_swarm.platform.protocols import JobStatus, ServingHandle
+from domyn_swarm.platform.protocols import JobStatus
 
 if TYPE_CHECKING:
     from ..swarm import DomynLLMSwarm
@@ -87,6 +87,17 @@ class SwarmStateManager:
 
     @classmethod
     def load(cls, deployment_name: str):
+        """Rehydrate a swarm from its persisted record.
+
+        Args:
+            deployment_name: The deployment name to look up.
+
+        Returns:
+            A fully-built :class:`DomynLLMSwarm`.
+
+        Raises:
+            JobNotFoundError: If no record exists for that name.
+        """
         from ... import DomynLLMSwarm  # avoid import cycles
 
         session_factory = make_session_factory(cls._get_db_path())
@@ -95,26 +106,7 @@ class SwarmStateManager:
         if rec is None:
             raise JobNotFoundError(deployment_name)
 
-        # Rehydrate
-        swarm_dict = rec.swarm
-        swarm_dict["cfg"] = rec.cfg
-        handle_dict = rec.serving_handle
-
-        swarm = DomynLLMSwarm.model_validate(swarm_dict)
-        serving_handle = ServingHandle(**handle_dict)
-
-        swarm.serving_handle = serving_handle
-        swarm._deployment._handle = serving_handle
-
-        assert swarm._plan is not None
-        if swarm.platform == "slurm" and serving_handle.meta.get("jobid") is None:
-            # The compute backend itself only needs lb_jobid/lb_node, but the
-            # Slurm serving backend later indexes handle.meta["jobid"]
-            # directly (see backends/serving/slurm.py). Fail loudly here,
-            # at load time, rather than with a bare KeyError deep in status().
-            raise ValueError("State file does not contain valid job IDs")
-        swarm._deployment.compute = swarm._plan.make_compute_backend(serving_handle)
-        return swarm
+        return DomynLLMSwarm.from_record(rec.swarm, rec.cfg, rec.serving_handle)
 
     @classmethod
     def load_monitor_view(cls, deployment_name: str):

--- a/src/domyn_swarm/core/state/state_manager.py
+++ b/src/domyn_swarm/core/state/state_manager.py
@@ -108,31 +108,6 @@ class SwarmStateManager:
 
         return DomynLLMSwarm.from_record(rec.swarm, rec.cfg, rec.serving_handle)
 
-    @classmethod
-    def load_monitor_view(cls, deployment_name: str):
-        """Lightweight read for read-only consumers (e.g. ``domyn-swarm monitor``).
-
-        Returns just the persisted endpoint and parsed config, WITHOUT constructing
-        a :class:`DomynLLMSwarm` — which would build the deployment plan and import
-        the whole serving backend (~400 modules) that monitoring never needs.
-
-        Returns:
-            An object exposing ``endpoint`` (str) and ``cfg`` (DomynLLMSwarmConfig).
-        """
-        from types import SimpleNamespace
-
-        from domyn_swarm.config.swarm import DomynLLMSwarmConfig
-
-        session_factory = make_session_factory(cls._get_db_path())
-        with session_factory() as s:
-            rec = s.get(SwarmRecord, deployment_name)
-        if rec is None:
-            raise JobNotFoundError(deployment_name)
-
-        cfg = DomynLLMSwarmConfig.model_validate(rec.cfg)
-        endpoint = (rec.swarm or {}).get("endpoint", "")
-        return SimpleNamespace(endpoint=endpoint, cfg=cfg)
-
     def delete_record(self, deployment_name: str) -> None:
         session_factory = make_session_factory(self._get_db_path())
         with session_factory() as s:

--- a/src/domyn_swarm/core/state/state_manager.py
+++ b/src/domyn_swarm/core/state/state_manager.py
@@ -107,7 +107,7 @@ class SwarmStateManager:
         swarm._deployment._handle = serving_handle
 
         assert swarm._plan is not None
-        if swarm._plan.platform == "slurm" and serving_handle.meta.get("jobid") is None:
+        if swarm.platform == "slurm" and serving_handle.meta.get("jobid") is None:
             # The compute backend itself only needs lb_jobid/lb_node, but the
             # Slurm serving backend later indexes handle.meta["jobid"]
             # directly (see backends/serving/slurm.py). Fail loudly here,
@@ -186,7 +186,7 @@ class SwarmStateManager:
                 "creation_dt": r.creation_dt.isoformat(),
                 # Optional: convenience fan-out of commonly used fields:
                 "endpoint": (r.swarm or {}).get("endpoint", ""),
-                "platform": (r.swarm or {}).get("_platform", ""),
+                "platform": (r.cfg or {}).get("backend", {}).get("type", ""),
                 "name": (r.swarm or {}).get("name", r.deployment_name),
             }
             for r in rows

--- a/src/domyn_swarm/core/swarm.py
+++ b/src/domyn_swarm/core/swarm.py
@@ -21,16 +21,15 @@ from pydantic import (
 from ulid import ULID
 
 from domyn_swarm import utils
-from domyn_swarm.backends.compute.slurm import SlurmComputeBackend
 from domyn_swarm.config.plan import DeploymentContext
 from domyn_swarm.config.settings import get_settings
-from domyn_swarm.config.slurm import SlurmConfig
 from domyn_swarm.config.swarm import DomynLLMSwarmConfig
 from domyn_swarm.deploy.deployment import Deployment
 from domyn_swarm.helpers.io import to_path
 from domyn_swarm.helpers.logger import setup_logger
 from domyn_swarm.helpers.swarm import generate_swarm_name
 from domyn_swarm.platform.protocols import (
+    ComputeBackend,
     JobHandle,
     JobProbe,
     JobStatus,
@@ -205,7 +204,11 @@ class DomynLLMSwarm(BaseModel):
             extras = plan.extras | {"swarm_directory": str(self.swarm_dir)}
             self._plan = plan
             self._platform = plan.platform
-            self._deployment = Deployment(serving=plan.serving, compute=plan.compute, extras=extras)
+            self._deployment = Deployment(
+                serving=plan.serving,
+                compute=plan.compute,  # type: ignore[arg-type]
+                extras=extras,
+            )
             return
 
     def __enter__(self):
@@ -990,18 +993,10 @@ class DomynLLMSwarm(BaseModel):
         short_id = str(unique_id)[:8]
         return f"{self.cfg.name}-{short_id}"
 
-    def _make_compute_backend(self, handle: ServingHandle):
-        if self._plan and self._plan.platform == "slurm":
-            lb_jobid = handle.meta.get("lb_jobid")
-            lb_node = handle.meta.get("lb_node")
-            if not lb_jobid or not lb_node:
-                raise RuntimeError("LB Job ID/Node missing in Slurm handle.")
-            assert self.cfg.backend is not None and isinstance(self.cfg.backend, SlurmConfig)
-            return SlurmComputeBackend(cfg=self.cfg.backend, lb_jobid=lb_jobid, lb_node=lb_node)
-        elif self._plan and self._plan.platform == "lepton":
-            return self._plan.compute
-        else:
-            raise RuntimeError(f"Unsupported platform for compute backend: {self._plan.platform}")
+    def _make_compute_backend(self, handle: ServingHandle) -> ComputeBackend:
+        """Build the compute backend for a ready serving handle."""
+        assert self._plan is not None
+        return self._plan.make_compute_backend(handle)
 
     def status(self) -> ServingStatus:
         """Get the current status of the swarm.

--- a/src/domyn_swarm/core/swarm.py
+++ b/src/domyn_swarm/core/swarm.py
@@ -1021,3 +1021,18 @@ class DomynLLMSwarm(BaseModel):
         if status.url is None:
             status.url = self.endpoint
         return status
+
+    def serving_status(self) -> ServingStatus:
+        """Ask the serving backend for this swarm's live status.
+
+        Unlike :meth:`status`, which reports what this object already knows,
+        this queries the backend directly. Safe at any point in the lifecycle:
+        a swarm that was never deployed reports
+        :attr:`~domyn_swarm.platform.protocols.ServingPhase.UNKNOWN`.
+
+        Returns:
+            The backend-reported serving status.
+        """
+        if self._deployment is None or self.serving_handle is None:
+            return ServingStatus(phase=ServingPhase.UNKNOWN, url=self.endpoint)
+        return self._deployment.serving.status(self.serving_handle)

--- a/src/domyn_swarm/core/swarm.py
+++ b/src/domyn_swarm/core/swarm.py
@@ -308,6 +308,39 @@ class DomynLLMSwarm(BaseModel):
         """
         return SwarmStateManager.load(deployment_name)
 
+    @classmethod
+    def from_record(
+        cls,
+        swarm_payload: dict,
+        cfg_payload: dict,
+        handle_payload: dict,
+    ) -> DomynLLMSwarm:
+        """Build a complete swarm from persisted state.
+
+        Args:
+            swarm_payload: The persisted ``swarm`` column, without ``cfg``.
+            cfg_payload: The persisted ``cfg`` column.
+            handle_payload: The persisted ``serving_handle`` column.
+
+        Returns:
+            A swarm with its handle adopted and its compute backend built.
+
+        Raises:
+            ValueError: If the record's serving handle is missing metadata the
+                platform needs; see
+                :meth:`~domyn_swarm.config.plan.DeploymentPlan.validate_serving_handle`.
+        """
+        swarm = cls.model_validate({**swarm_payload, "cfg": cfg_payload})
+        handle = ServingHandle(**handle_payload)
+
+        assert swarm._plan is not None, "Swarm was built without a deployment plan"
+        swarm._plan.validate_serving_handle(handle)
+
+        swarm.serving_handle = handle
+        swarm._deployment.adopt(handle)
+        swarm._deployment.compute = swarm._plan.make_compute_backend(handle)
+        return swarm
+
     def _delete_record(self) -> None:
         """Delete swarm from the DB
 

--- a/src/domyn_swarm/core/swarm.py
+++ b/src/domyn_swarm/core/swarm.py
@@ -15,12 +15,13 @@ import warnings
 from pydantic import (
     BaseModel,
     Field,
+    PrivateAttr,
     computed_field,
 )
 from ulid import ULID
 
 from domyn_swarm import utils
-from domyn_swarm.config.plan import DeploymentContext
+from domyn_swarm.config.plan import DeploymentContext, DeploymentPlan
 from domyn_swarm.config.settings import get_settings
 from domyn_swarm.config.swarm import DomynLLMSwarmConfig
 from domyn_swarm.deploy.deployment import Deployment
@@ -159,6 +160,9 @@ class DomynLLMSwarm(BaseModel):
         default_factory=lambda data: data["swarm_dir"] / "watchdog.db",
     )
 
+    _plan_cache: DeploymentPlan | None = PrivateAttr(default=None)
+    _deployment_cache: Deployment | None = PrivateAttr(default=None)
+
     @computed_field
     @property
     def model(self) -> str:
@@ -187,9 +191,19 @@ class DomynLLMSwarm(BaseModel):
         return self.cfg.backend.type
 
     def model_post_init(self, __context: Any) -> None:
-        """Post-init to set up the deployment backend."""
+        """Wire up in-memory collaborators. Performs no I/O."""
+        self._cleaned = False
+        self._state_mgr = SwarmStateManager(self)
 
-        swarm_dirs = [
+    def ensure_directories(self) -> None:
+        """Create this swarm's on-disk layout. Idempotent.
+
+        Called before deploying (the sbatch templates reference these paths and
+        Slurm rejects a submission whose output directory is missing) and before
+        writing checkpoints on a swarm reattached via :meth:`from_state`, which
+        does not pass through the context manager.
+        """
+        for directory in (
             self.swarm_dir,
             self.swarm_dir / "serving",
             self.swarm_dir / "jobs",
@@ -197,28 +211,47 @@ class DomynLLMSwarm(BaseModel):
             self.swarm_dir / "logs" / "endpoint",
             self.swarm_dir / "logs" / "replicas",
             self.swarm_dir / "logs" / "slurm",
-        ]
-        for d in swarm_dirs:
-            os.makedirs(d, exist_ok=True)
+        ):
+            os.makedirs(directory, exist_ok=True)
 
-        self._cleaned = False
-        self._state_mgr = SwarmStateManager(self)
+    @property
+    def _plan(self) -> DeploymentPlan:
+        """The deployment plan, built on first access.
 
-        plan = self.cfg.get_deployment_plan()
-        if plan is None and self.cfg.backend is not None:
-            plan = self.cfg.build_plan()
+        Returns:
+            The plan for this swarm's configured backend.
 
-        if plan is not None:
-            extras = plan.extras | {"swarm_directory": str(self.swarm_dir)}
-            self._plan = plan
-            self._deployment = Deployment(
+        Raises:
+            RuntimeError: If the config carries no backend, so no plan exists.
+        """
+        if self._plan_cache is None:
+            plan = self.cfg.get_deployment_plan()
+            if plan is None and self.cfg.backend is not None:
+                plan = self.cfg.build_plan()
+            if plan is None:
+                raise RuntimeError("Swarm config has no backend, so no plan can be built")
+            self._plan_cache = plan
+        return self._plan_cache
+
+    @property
+    def _deployment(self) -> Deployment:
+        """The deployment, built on first access from the plan.
+
+        Returns:
+            The (serving, compute) pair this swarm drives.
+        """
+        if self._deployment_cache is None:
+            plan = self._plan
+            self._deployment_cache = Deployment(
                 serving=plan.serving,
                 compute=plan.compute,  # type: ignore[arg-type]
-                extras=extras,
+                extras=plan.extras | {"swarm_directory": str(self.swarm_dir)},
             )
-            return
+        return self._deployment_cache
 
     def __enter__(self):
+        self.ensure_directories()
+
         # If instantiating from state, the swarm will be already deployed,
         # so just return self
         if self.serving_handle is not None:
@@ -594,6 +627,10 @@ class DomynLLMSwarm(BaseModel):
                 stacklevel=2,
             )
             num_shards = num_threads
+
+        # A swarm reattached via `from_state` never passed through the context
+        # manager, so its layout may not exist yet.
+        self.ensure_directories()
 
         if checkpoint_dir is None:
             checkpoint_dir = self.swarm_dir / "checkpoints"
@@ -1019,7 +1056,9 @@ class DomynLLMSwarm(BaseModel):
         """
         if self._cleaned:
             return
-        if self._deployment and self.serving_handle:
+        # Handle first: a swarm that never deployed needs no deployment built
+        # just to decide there is nothing to tear down.
+        if self.serving_handle and self._deployment:
             self._deployment.down(self.serving_handle)
         self._delete_record()
         self._cleaned = True
@@ -1066,6 +1105,8 @@ class DomynLLMSwarm(BaseModel):
         Returns:
             The backend-reported serving status.
         """
-        if self._deployment is None or self.serving_handle is None:
+        # Handle first, so a never-deployed swarm answers without building a
+        # deployment (and importing its serving backend) to do it.
+        if self.serving_handle is None or self._deployment is None:
             return ServingStatus(phase=ServingPhase.UNKNOWN, url=self.endpoint)
         return self._deployment.serving.status(self.serving_handle)

--- a/src/domyn_swarm/core/swarm.py
+++ b/src/domyn_swarm/core/swarm.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
     from domyn_swarm.jobs import SwarmJob
 
 logger = setup_logger(__name__, level=logging.INFO)
-settings = get_settings()
 
 
 class DomynLLMSwarm(BaseModel):
@@ -640,7 +639,7 @@ class DomynLLMSwarm(BaseModel):
                 "JOB_CLASS": job_class,
             }
         )
-        token = settings.api_token or settings.vllm_api_key or settings.singularityenv_vllm_api_key
+        token = get_settings().resolved_api_token
         if token:
             env["DOMYN_SWARM_API_TOKEN"] = token.get_secret_value()
             env["VLLM_API_KEY"] = token.get_secret_value()

--- a/src/domyn_swarm/core/swarm.py
+++ b/src/domyn_swarm/core/swarm.py
@@ -15,7 +15,6 @@ import warnings
 from pydantic import (
     BaseModel,
     Field,
-    PrivateAttr,
     computed_field,
 )
 from ulid import ULID
@@ -151,7 +150,6 @@ class DomynLLMSwarm(BaseModel):
         False  # Delete the resources for this cluster at the end of the job
     )
     serving_handle: ServingHandle | None = None  # ServingHandle, set after deployment
-    _platform: str = PrivateAttr("")
     swarm_dir: utils.EnvPath = Field(
         description="Directory where swarm-related files are stored",
         default_factory=lambda data: data["cfg"].home_directory / "swarms" / data["name"],
@@ -178,6 +176,16 @@ class DomynLLMSwarm(BaseModel):
         """
         self.cfg.model = value
 
+    @property
+    def platform(self) -> str:
+        """The platform this swarm deploys to, e.g. ``"slurm"`` or ``"lepton"``.
+
+        Derived from ``cfg.backend.type``, which is the authoritative value and
+        is present in every persisted record.
+        """
+        assert self.cfg.backend is not None, "Swarm config has no backend"
+        return self.cfg.backend.type
+
     def model_post_init(self, __context: Any) -> None:
         """Post-init to set up the deployment backend."""
 
@@ -203,7 +211,6 @@ class DomynLLMSwarm(BaseModel):
         if plan is not None:
             extras = plan.extras | {"swarm_directory": str(self.swarm_dir)}
             self._plan = plan
-            self._platform = plan.platform
             self._deployment = Deployment(
                 serving=plan.serving,
                 compute=plan.compute,  # type: ignore[arg-type]
@@ -229,7 +236,7 @@ class DomynLLMSwarm(BaseModel):
             image=self._plan.image,
         )
 
-        logger.info(f"Creating deployment [cyan]{self.name}[/cyan] on {self._platform}...")
+        logger.info(f"Creating deployment [cyan]{self.name}[/cyan] on {self.platform}...")
 
         handle = self._deployment.up(self.name, ctx)
 
@@ -337,7 +344,7 @@ class DomynLLMSwarm(BaseModel):
         try:
             job_id = SwarmStateManager.create_job(
                 deployment_name=self.name,
-                provider=self._platform,
+                provider=self.platform,
                 kind=kind,
                 status=status,
                 external_id=external_id,
@@ -597,7 +604,7 @@ class DomynLLMSwarm(BaseModel):
 
         logger.info(
             f"Submitting {job.__class__.__name__} [cyan]{job_name}[/cyan] job "
-            f"to swarm {self.name} on {self._platform}"
+            f"to swarm {self.name} on {self.platform}"
         )
 
         return self._submit_with_tracking(
@@ -837,7 +844,7 @@ class DomynLLMSwarm(BaseModel):
         """
 
         # Basic validation
-        if self._platform == "slurm" and not script_path.is_file():
+        if self.platform == "slurm" and not script_path.is_file():
             raise FileNotFoundError(f"Script not found: {script_path}")
 
         # Compose runtime (interpreter/image/resources/env) once

--- a/src/domyn_swarm/deploy/deployment.py
+++ b/src/domyn_swarm/deploy/deployment.py
@@ -44,6 +44,17 @@ class Deployment:
         self.extras = merged_extras
         return handle
 
+    def adopt(self, handle: ServingHandle) -> None:
+        """Attach an existing serving handle to this deployment.
+
+        Used when rehydrating a deployment that is already running, so callers
+        do not have to write ``_handle`` directly.
+
+        Args:
+            handle: The handle recovered from persisted state.
+        """
+        self._handle = handle
+
     def wait_ready(self, timeout_s: int, *, extras: dict | None = None) -> ServingHandle:
         """Wait for the current serving endpoint to be ready."""
         if self._handle is None:

--- a/src/domyn_swarm/jobs/api/base.py
+++ b/src/domyn_swarm/jobs/api/base.py
@@ -47,8 +47,6 @@ from .batching import BatchExecutor
 
 logger = setup_logger(__name__, level=logging.INFO)
 
-settings = get_settings()
-
 
 class OutputJoinMode(str, Enum):
     APPEND = "append"
@@ -299,7 +297,7 @@ class SwarmJob(abc.ABC):
         self.native_batch_size = native_batch_size
 
         headers = {}
-        token = settings.api_token or settings.vllm_api_key or settings.singularityenv_vllm_api_key
+        token = get_settings().resolved_api_token
         if token:
             logger.info("Using API_TOKEN from environment for authentication")
             headers["Authorization"] = f"Bearer {token.get_secret_value()}"

--- a/src/domyn_swarm/platform/http_probe.py
+++ b/src/domyn_swarm/platform/http_probe.py
@@ -24,8 +24,7 @@ def wait_http_200(
     on_tick: Callable[[], None] | None = None,
 ) -> None:
     deadline = now() + timeout_s
-    settings = get_settings()
-    token = settings.api_token or settings.vllm_api_key or settings.singularityenv_vllm_api_key
+    token = get_settings().resolved_api_token
     while now() < deadline:
         if on_tick:
             on_tick()

--- a/tests/cli/test_cli_swarm_describe.py
+++ b/tests/cli/test_cli_swarm_describe.py
@@ -14,7 +14,7 @@ class DummyCfg(BaseModel):
 
 class FakeSwarm:
     def __init__(self, platform="slurm", endpoint="http://host:9000", cfg=None):
-        self._platform = platform
+        self.platform = platform
         self.endpoint = endpoint
         self.cfg = cfg or DummyCfg()
 

--- a/tests/cli/test_cli_swarm_list.py
+++ b/tests/cli/test_cli_swarm_list.py
@@ -17,16 +17,9 @@ def _rec(name="alpha", platform="slurm", endpoint="http://alpha:9000"):
 
 
 def _fake_swarm_with_status(status: ServingStatus):
-    class _Serving:
-        def status(self, handle):
-            return status
-
-    class _Dep:
-        serving = _Serving()
-
     class _Swarm:
-        _deployment = _Dep()
-        serving_handle = object()
+        def serving_status(self):
+            return status
 
     return _Swarm()
 

--- a/tests/cli/test_db.py
+++ b/tests/cli/test_db.py
@@ -34,16 +34,9 @@ def test_db_stamp_uses_home(monkeypatch, tmp_path):
 
 
 def _fake_swarm_with_status(status: ServingStatus):
-    class _Serving:
-        def status(self, handle):
-            return status
-
-    class _Dep:
-        serving = _Serving()
-
     class _Swarm:
-        _deployment = _Dep()
-        serving_handle = object()
+        def serving_status(self):
+            return status
 
     return _Swarm()
 

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -54,9 +54,7 @@ def test_monitor_uses_custom_dashboard(monkeypatch, tmp_path):
 
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
-    monkeypatch.setattr(
-        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
-    )
+    monkeypatch.setattr(SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm))
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}
     monkeypatch.setattr(monitor_mod.os, "execvp", lambda f, argv: captured.update(argv=argv))
@@ -72,9 +70,7 @@ def test_monitor_rejects_missing_custom_dashboard(monkeypatch, tmp_path):
 
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
-    monkeypatch.setattr(
-        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
-    )
+    monkeypatch.setattr(SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm))
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
 
     with pytest.raises(typer.Exit) as ei:
@@ -99,9 +95,7 @@ def test_monitor_autofills_and_overrides_variables(monkeypatch):
 
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
-    monkeypatch.setattr(
-        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
-    )
+    monkeypatch.setattr(SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm))
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}
     monkeypatch.setattr(monitor_mod.os, "execvp", lambda f, argv: captured.update(argv=argv))
@@ -126,9 +120,7 @@ def test_monitor_exits_cleanly_when_endpoint_has_no_monitoring(monkeypatch):
 
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
-    monkeypatch.setattr(
-        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
-    )
+    monkeypatch.setattr(SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm))
 
     with pytest.raises(typer.Exit) as ei:
         monitor_mod.monitor("some-swarm")
@@ -197,9 +189,7 @@ def test_monitor_appends_ray_panels_when_ray_metrics_enabled(monkeypatch, tmp_pa
 
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
-    monkeypatch.setattr(
-        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
-    )
+    monkeypatch.setattr(SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm))
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}
     monkeypatch.setattr(monitor_mod.os, "execvp", lambda f, argv: captured.update(argv=argv))
@@ -221,9 +211,7 @@ def test_monitor_skips_ray_panels_when_dashboard_overridden(monkeypatch, tmp_pat
 
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
-    monkeypatch.setattr(
-        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
-    )
+    monkeypatch.setattr(SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm))
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}
     monkeypatch.setattr(monitor_mod.os, "execvp", lambda f, argv: captured.update(argv=argv))

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -55,7 +55,7 @@ def test_monitor_uses_custom_dashboard(monkeypatch, tmp_path):
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
     monkeypatch.setattr(
-        SwarmStateManager, "load_monitor_view", classmethod(lambda cls, deployment_name: swarm)
+        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
     )
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}
@@ -73,7 +73,7 @@ def test_monitor_rejects_missing_custom_dashboard(monkeypatch, tmp_path):
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
     monkeypatch.setattr(
-        SwarmStateManager, "load_monitor_view", classmethod(lambda cls, deployment_name: swarm)
+        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
     )
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
 
@@ -100,7 +100,7 @@ def test_monitor_autofills_and_overrides_variables(monkeypatch):
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
     monkeypatch.setattr(
-        SwarmStateManager, "load_monitor_view", classmethod(lambda cls, deployment_name: swarm)
+        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
     )
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}
@@ -127,7 +127,7 @@ def test_monitor_exits_cleanly_when_endpoint_has_no_monitoring(monkeypatch):
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
     monkeypatch.setattr(
-        SwarmStateManager, "load_monitor_view", classmethod(lambda cls, deployment_name: swarm)
+        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
     )
 
     with pytest.raises(typer.Exit) as ei:
@@ -198,7 +198,7 @@ def test_monitor_appends_ray_panels_when_ray_metrics_enabled(monkeypatch, tmp_pa
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
     monkeypatch.setattr(
-        SwarmStateManager, "load_monitor_view", classmethod(lambda cls, deployment_name: swarm)
+        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
     )
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}
@@ -222,7 +222,7 @@ def test_monitor_skips_ray_panels_when_dashboard_overridden(monkeypatch, tmp_pat
     from domyn_swarm.core.state.state_manager import SwarmStateManager
 
     monkeypatch.setattr(
-        SwarmStateManager, "load_monitor_view", classmethod(lambda cls, deployment_name: swarm)
+        SwarmStateManager, "load", classmethod(lambda cls, deployment_name: swarm)
     )
     monkeypatch.setattr(monitor_mod.shutil, "which", lambda _: "/usr/bin/grafatui")
     captured: dict = {}

--- a/tests/config/test_plan_compute_backend.py
+++ b/tests/config/test_plan_compute_backend.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+"""A DeploymentPlan must be able to finish building its own compute backend."""
+
+import pytest
+
+from domyn_swarm.config.slurm import SlurmConfig, SlurmEndpointConfig
+from domyn_swarm.config.swarm import DomynLLMSwarmConfig
+from domyn_swarm.platform.protocols import ComputeBackend, ServingHandle
+
+
+def _slurm_cfg() -> DomynLLMSwarmConfig:
+    return DomynLLMSwarmConfig(
+        name="fake",
+        hf_home=".",
+        image="image",
+        model="Qwen/Qwen3-32B",
+        revision=None,
+        replicas=1,
+        gpus_per_node=1,
+        gpus_per_replica=1,
+        replicas_per_node=1,
+        nodes=1,
+        port=1000,
+        cpus_per_task=2,
+        mem_per_cpu="1GB",
+        wait_endpoint_s=1200,
+        backend=SlurmConfig(
+            type="slurm",
+            partition="partition",
+            account="account",
+            qos="qos",
+            requires_ray=False,
+            endpoint=SlurmEndpointConfig(
+                cpus_per_task=1,
+                nginx_image="/path/to/vllm.sif",
+                mem="1GB",
+                threads_per_core=1,
+                wall_time="24:00:00",
+                enable_proxy_buffering=True,
+                nginx_timeout="60s",
+            ),
+        ),
+    )
+
+
+def _ready_slurm_handle() -> ServingHandle:
+    return ServingHandle(
+        id="1234",
+        url="http://lb:9003",
+        meta={"lb_jobid": 1234, "jobid": 5678, "lb_node": "lrdn4759", "port": 9003},
+    )
+
+
+def test_slurm_plan_builds_a_real_compute_backend_from_the_handle() -> None:
+    """The plan, not the swarm, turns a ready handle into a compute backend."""
+    plan = _slurm_cfg().build_plan()
+
+    backend = plan.make_compute_backend(_ready_slurm_handle())
+
+    assert isinstance(backend, ComputeBackend)
+    assert backend.lb_jobid == 1234
+    assert backend.lb_node == "lrdn4759"
+
+
+def test_slurm_plan_holds_no_placeholder_compute_backend() -> None:
+    """Before a handle exists there is no compute backend, not a fake one."""
+    plan = _slurm_cfg().build_plan()
+
+    assert plan.compute is None
+
+
+def test_slurm_plan_rejects_a_handle_without_lb_metadata() -> None:
+    """A handle missing lb_jobid/lb_node fails loudly, naming what is missing."""
+    plan = _slurm_cfg().build_plan()
+    incomplete = ServingHandle(id="1234", url="", meta={"jobid": 5678})
+
+    with pytest.raises(RuntimeError, match="lb_jobid"):
+        plan.make_compute_backend(incomplete)
+
+
+def test_plan_platform_is_an_open_string() -> None:
+    """`platform` must not be a closed union, or a third backend cannot be added."""
+    import typing
+
+    from domyn_swarm.config.plan import DeploymentPlan
+
+    hints = typing.get_type_hints(DeploymentPlan)
+
+    assert hints["platform"] is str

--- a/tests/config/test_plan_compute_backend.py
+++ b/tests/config/test_plan_compute_backend.py
@@ -89,3 +89,25 @@ def test_plan_platform_is_an_open_string() -> None:
     hints = typing.get_type_hints(DeploymentPlan)
 
     assert hints["platform"] is str
+
+
+def test_slurm_plan_rejects_a_persisted_handle_without_a_jobid() -> None:
+    """Validating a rehydrated handle is the plan's job, not the swarm's.
+
+    ``SlurmServingBackend.status()`` subscripts ``meta["jobid"]``, so a record
+    without one has to be rejected before it is adopted.
+    """
+    plan = _slurm_cfg().build_plan()
+    no_jobid = ServingHandle(
+        id="1234", url="http://lb:9003", meta={"lb_jobid": 1234, "lb_node": "n1"}
+    )
+
+    with pytest.raises(ValueError, match="job IDs"):
+        plan.validate_serving_handle(no_jobid)
+
+
+def test_plan_validation_accepts_a_ready_slurm_handle() -> None:
+    """A complete handle passes validation without raising."""
+    plan = _slurm_cfg().build_plan()
+
+    plan.validate_serving_handle(_ready_slurm_handle())

--- a/tests/config/test_settings_point_of_use.py
+++ b/tests/config/test_settings_point_of_use.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+"""Settings must be read when used, not captured at import time."""
+
+import pytest
+
+from domyn_swarm.config.settings import Settings, get_settings, reload_settings_cache
+
+
+def test_api_token_set_after_import_reaches_the_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token exported after `domyn_swarm` is imported must still authenticate.
+
+    Regression test for a module-scope ``settings = get_settings()`` binding,
+    which freezes the token as of first import.
+    """
+    import domyn_swarm.jobs.api.base as base
+    from domyn_swarm.jobs.api.chat_completion import ChatCompletionJob
+
+    captured: dict = {}
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(base, "AsyncOpenAI", FakeAsyncOpenAI)
+    monkeypatch.setenv("DOMYN_SWARM_API_TOKEN", "token-set-after-import")
+    reload_settings_cache()
+
+    ChatCompletionJob(model="some-model", endpoint="http://localhost:8000")
+
+    assert captured["default_headers"]["Authorization"] == "Bearer token-set-after-import"
+
+
+def test_resolved_api_token_prefers_api_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``api_token`` wins over the vLLM-compatible aliases."""
+    monkeypatch.setenv("DOMYN_SWARM_API_TOKEN", "primary")
+    monkeypatch.setenv("VLLM_API_KEY", "secondary")
+    reload_settings_cache()
+
+    token = get_settings().resolved_api_token
+
+    assert token is not None
+    assert token.get_secret_value() == "primary"
+
+
+def test_resolved_api_token_is_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No token configured resolves to ``None`` rather than an empty secret."""
+    monkeypatch.delenv("DOMYN_SWARM_API_TOKEN", raising=False)
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    monkeypatch.delenv("SINGULARITYENV_VLLM_API_KEY", raising=False)
+    reload_settings_cache()
+
+    assert Settings().resolved_api_token is None
+
+
+def test_no_module_scope_settings_bindings() -> None:
+    """No module may capture ``get_settings()`` at import time.
+
+    A module-scope binding cannot be refreshed by ``reload_settings_cache()``,
+    so it silently freezes configuration as of first import. This guard has a
+    history: the binding pattern was removed once and came back.
+    """
+    import ast
+    import pathlib
+
+    src_root = pathlib.Path(__file__).resolve().parents[2] / "src" / "domyn_swarm"
+    offenders: list[str] = []
+
+    for path in sorted(src_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in tree.body:  # module scope only, not nested bodies
+            if not isinstance(node, ast.Assign):
+                continue
+            call = node.value
+            if isinstance(call, ast.Call) and getattr(call.func, "id", None) == "get_settings":
+                offenders.append(f"{path.relative_to(src_root)}:{node.lineno}")
+
+    assert offenders == [], (
+        "get_settings() must be called at the point of use, not bound at module "
+        f"scope. Offending bindings: {offenders}"
+    )

--- a/tests/core/test_swarm.py
+++ b/tests/core/test_swarm.py
@@ -186,7 +186,7 @@ def cfg_stub(tmp_path):
         name="name",
         model="m1",
         wait_endpoint_s=30,
-        backend=SimpleNamespace(env={"X": "Y"}),
+        backend=SimpleNamespace(env={"X": "Y"}, type="lepton"),
         home_directory=tmp_path,
     )
     stub.get_deployment_plan = lambda: FakePlan(platform="lepton")
@@ -197,7 +197,10 @@ def cfg_stub(tmp_path):
 def make_swarm(cfg):
     """
     Create a DomynLLMSwarm instance using model_construct to avoid
-    pydantic validations and then manually inject plan/deployment/platform/state.
+    pydantic validations and then manually inject plan/deployment/state.
+
+    `platform` is a read-only property derived from `cfg.backend.type`, so it
+    needs no manual injection here.
     """
     # pydantic v2: model_construct
     swarm = DomynLLMSwarm.model_construct(
@@ -210,7 +213,6 @@ def make_swarm(cfg):
     # Inject state mgr and deployment based on plan (like model_post_init would)
     plan = cfg.get_deployment_plan()
     swarm._plan = plan  # type: ignore[attr-defined]
-    swarm._platform = plan.platform  # type: ignore[attr-defined]
     swarm._deployment = FakeDeployment(
         serving=plan.serving, compute=plan.compute, extras=plan.extras
     )  # type: ignore[attr-defined]
@@ -252,7 +254,7 @@ def test_exit_with_delete_on_exit_calls_cleanup(cfg_stub):
 @pytest.mark.skip(reason="Validation not implemented yet")
 def test_deployment_name_sanitization_lepton(cfg_stub):
     swarm = make_swarm(cfg_stub)
-    swarm._platform = "lepton"  # type: ignore[attr-defined]
+    swarm.cfg.backend.type = "lepton"
     swarm.name = "Bad*Name/With Spaces & VeryVeryVeryVeryVeryLong0123456789"
     out = swarm._deployment_name()
     assert all(ch.isalnum() or ch in "-_" for ch in out)
@@ -263,7 +265,7 @@ def test_deployment_name_sanitization_lepton(cfg_stub):
 @pytest.mark.skip(reason="Validation not implemented yet")
 def test_deployment_name_sanitization_slurm(cfg_stub):
     swarm = make_swarm(cfg_stub)
-    swarm._platform = "slurm"  # type: ignore[attr-defined]
+    swarm.cfg.backend.type = "slurm"
     swarm.name = "Ok_Name-123$%^"
     out = swarm._deployment_name()
     assert all(ch.isalnum() or ch in "-_" for ch in out)

--- a/tests/core/test_swarm.py
+++ b/tests/core/test_swarm.py
@@ -131,10 +131,11 @@ class FakeComputeBackend:
 
 
 class FakePlan:
-    def __init__(self, platform="lepton"):
+    def __init__(self, platform="lepton", compute=None, compute_factory=None):
         self.platform = platform
         self.serving = SimpleNamespace()
-        self.compute = FakeComputeBackend()
+        self.compute = compute if compute is not None else FakeComputeBackend()
+        self.compute_factory = compute_factory
         self.serving_spec = {"replicas": 1, "resource_shape": "gpu.4xh200"}
         self.name_hint = platform
         self.extras = {}
@@ -142,6 +143,14 @@ class FakePlan:
         self.shared_env = {}
         self.image = None
         self.timeout_s = None
+
+    def make_compute_backend(self, handle):
+        """Mirror `DeploymentPlan.make_compute_backend` for delegation tests."""
+        if self.compute_factory is not None:
+            return self.compute_factory(handle)
+        if self.compute is not None:
+            return self.compute
+        raise RuntimeError(f"Platform {self.platform!r} supplies no compute backend")
 
 
 # ---------------------------
@@ -561,26 +570,26 @@ def test_from_state_forwards_to_state_manager(monkeypatch, patch_state_mgr):
     assert out.deployment_name == "name"
 
 
-def test_make_compute_backend_slurm_happy_path(monkeypatch, tmp_path):
-    # Patch SlurmConfig and SlurmComputeBackend in the module so isinstance checks pass
-    class _SlurmConfig:
-        pass
-
+def test_make_compute_backend_slurm_happy_path(tmp_path):
+    # `_make_compute_backend` now just delegates to `plan.make_compute_backend`;
+    # exercise that delegation through a fake plan with a Slurm-shaped factory.
     class _SlurmCompute:
-        def __init__(self, cfg, lb_jobid, lb_node):
-            self.cfg, self.lb_jobid, self.lb_node = cfg, lb_jobid, lb_node
+        def __init__(self, lb_jobid, lb_node):
+            self.lb_jobid, self.lb_node = lb_jobid, lb_node
 
-    monkeypatch.setattr(mod, "SlurmConfig", _SlurmConfig)
-    monkeypatch.setattr(mod, "SlurmComputeBackend", _SlurmCompute)
+    def _compute_factory(handle):
+        return _SlurmCompute(handle.meta["lb_jobid"], handle.meta["lb_node"])
 
     cfg = SimpleNamespace(
         name="n",
         model="m1",
         wait_endpoint_s=5,
-        backend=_SlurmConfig(),
+        backend=SimpleNamespace(),
         home_directory=tmp_path,
     )
-    cfg.get_deployment_plan = lambda: FakePlan(platform="slurm")
+    cfg.get_deployment_plan = lambda: FakePlan(
+        platform="slurm", compute=None, compute_factory=_compute_factory
+    )
     swarm = make_swarm(cfg)
 
     # Fake handle with required metadata:
@@ -592,24 +601,32 @@ def test_make_compute_backend_slurm_happy_path(monkeypatch, tmp_path):
     assert comp.lb_jobid == 777 and comp.lb_node == "nodeX"
 
 
-def test_make_compute_backend_slurm_missing_meta_raises(monkeypatch, tmp_path):
-    class _SlurmConfig:
-        pass
-
-    monkeypatch.setattr(mod, "SlurmConfig", _SlurmConfig)
+def test_make_compute_backend_slurm_missing_meta_raises(tmp_path):
+    def _compute_factory(handle):
+        lb_jobid = handle.meta.get("lb_jobid")
+        lb_node = handle.meta.get("lb_node")
+        if not lb_jobid or not lb_node:
+            raise RuntimeError(
+                "Slurm serving handle is missing load-balancer metadata "
+                f"(lb_jobid={lb_jobid!r}, lb_node={lb_node!r}); the endpoint "
+                "is not ready."
+            )
+        return lb_jobid, lb_node  # pragma: no cover - unreachable in this test
 
     cfg = SimpleNamespace(
         name="",
         model="m1",
         wait_endpoint_s=5,
-        backend=_SlurmConfig(),
+        backend=SimpleNamespace(),
         home_directory=tmp_path,
     )
-    cfg.get_deployment_plan = lambda: FakePlan(platform="slurm")
+    cfg.get_deployment_plan = lambda: FakePlan(
+        platform="slurm", compute=None, compute_factory=_compute_factory
+    )
     swarm = make_swarm(cfg)
 
     handle = SimpleNamespace(id="dep", url="", meta={})  # missing lb_* keys
-    with pytest.raises(RuntimeError, match="LB Job ID/Node missing"):
+    with pytest.raises(RuntimeError, match="lb_jobid"):
         swarm._make_compute_backend(handle)
 
 

--- a/tests/core/test_swarm.py
+++ b/tests/core/test_swarm.py
@@ -199,8 +199,9 @@ def make_swarm(cfg):
     Create a DomynLLMSwarm instance using model_construct to avoid
     pydantic validations and then manually inject plan/deployment/state.
 
-    `platform` is a read-only property derived from `cfg.backend.type`, so it
-    needs no manual injection here.
+    `_plan` and `_deployment` are lazy read-only properties, so the fakes go
+    into the caches they memoize into. `platform` is a read-only property
+    derived from `cfg.backend.type`, so it needs no manual injection here.
     """
     # pydantic v2: model_construct
     swarm = DomynLLMSwarm.model_construct(
@@ -210,12 +211,12 @@ def make_swarm(cfg):
         delete_on_exit=False,
         serving_handle=None,
     )
-    # Inject state mgr and deployment based on plan (like model_post_init would)
+    # Inject state mgr and deployment based on plan, pre-empting the lazy build
     plan = cfg.get_deployment_plan()
-    swarm._plan = plan  # type: ignore[attr-defined]
-    swarm._deployment = FakeDeployment(
+    swarm._plan_cache = plan  # type: ignore[assignment]
+    swarm._deployment_cache = FakeDeployment(
         serving=plan.serving, compute=plan.compute, extras=plan.extras
-    )  # type: ignore[attr-defined]
+    )  # type: ignore[assignment]
     swarm._state_mgr = FakeStateMgr(swarm)  # type: ignore[attr-defined]
     return swarm
 
@@ -767,7 +768,7 @@ def test_refresh_job_status_probe_error_is_best_effort(cfg_stub, monkeypatch):
 def test_status_reports_unknown_before_deployment(cfg_stub, mocker):
     """A swarm that was never deployed reports UNKNOWN rather than raising."""
     swarm = make_swarm(cfg_stub)
-    swarm._deployment = Deployment(serving=mocker.Mock(), compute=mocker.Mock())
+    swarm._deployment_cache = Deployment(serving=mocker.Mock(), compute=mocker.Mock())
 
     status = swarm.status()
 
@@ -778,7 +779,7 @@ def test_status_keeps_known_endpoint_when_backend_reports_none(cfg_stub, mocker)
     """A recovered swarm still reports the endpoint it knows about."""
     swarm = make_swarm(cfg_stub)
     swarm.endpoint = "http://recovered:9000"
-    swarm._deployment = Deployment(serving=mocker.Mock(), compute=mocker.Mock())
+    swarm._deployment_cache = Deployment(serving=mocker.Mock(), compute=mocker.Mock())
 
     status = swarm.status()
 

--- a/tests/core/test_swarm_seams.py
+++ b/tests/core/test_swarm_seams.py
@@ -216,3 +216,54 @@ def test_from_record_rejects_an_incoherent_slurm_record(swarm: DomynLLMSwarm) ->
 
     with pytest.raises(ValueError, match="job IDs"):
         SwarmStateManager.load(deployment_name="swarm")
+
+
+def test_construction_creates_no_directories(
+    db_path: Path, slurm_cfg: DomynLLMSwarmConfig, tmp_path: Path
+) -> None:
+    """Instantiating a swarm must not touch the filesystem."""
+    before = set(tmp_path.rglob("*"))
+
+    DomynLLMSwarm(name="inert", cfg=slurm_cfg)
+
+    assert set(tmp_path.rglob("*")) == before
+
+
+def test_ensure_directories_is_idempotent(db_path: Path, slurm_cfg: DomynLLMSwarmConfig) -> None:
+    """The directory layout is created on demand, and calling twice is safe."""
+    swarm = DomynLLMSwarm(name="dirs", cfg=slurm_cfg)
+
+    swarm.ensure_directories()
+    swarm.ensure_directories()
+
+    for sub in (
+        "serving",
+        "jobs",
+        "checkpoints",
+        "logs/endpoint",
+        "logs/replicas",
+        "logs/slurm",
+    ):
+        assert (swarm.swarm_dir / sub).is_dir(), f"missing {sub}"
+
+
+def test_construction_imports_no_serving_backend(
+    db_path: Path, slurm_cfg: DomynLLMSwarmConfig
+) -> None:
+    """A cheap constructor is what lets read-only consumers use the real swarm.
+
+    Guards the deletion of load_monitor_view, whose docstring justified itself
+    by the ~400 modules a constructor used to pull in.
+    """
+    import subprocess
+    import sys
+
+    script = (
+        "import sys;"
+        "import domyn_swarm.core.swarm as m;"
+        "assert 'domyn_swarm.backends.serving.slurm' not in sys.modules, "
+        "'serving backend imported at module load'"
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr

--- a/tests/core/test_swarm_seams.py
+++ b/tests/core/test_swarm_seams.py
@@ -267,3 +267,10 @@ def test_construction_imports_no_serving_backend(
     result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
 
     assert result.returncode == 0, result.stderr
+
+
+def test_monitor_reads_through_the_normal_load_path() -> None:
+    """There is one read path for persisted swarms, not two."""
+    from domyn_swarm.core.state import state_manager
+
+    assert not hasattr(state_manager.SwarmStateManager, "load_monitor_view")

--- a/tests/core/test_swarm_seams.py
+++ b/tests/core/test_swarm_seams.py
@@ -29,9 +29,7 @@ def _init_schema(db_path: Path) -> None:
 def db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point SwarmStateManager at a temporary SQLite DB with the schema created."""
     path = tmp_path / SwarmStateManager.DB_NAME
-    monkeypatch.setattr(
-        SwarmStateManager, "_get_db_path", classmethod(lambda cls: path)
-    )
+    monkeypatch.setattr(SwarmStateManager, "_get_db_path", classmethod(lambda cls: path))
     _init_schema(path)
     return path
 

--- a/tests/core/test_swarm_seams.py
+++ b/tests/core/test_swarm_seams.py
@@ -114,3 +114,34 @@ def test_saved_swarm_reports_its_platform_in_list_all(swarm: DomynLLMSwarm) -> N
     row = next(r for r in rows if r["deployment_name"] == "swarm")
 
     assert row["platform"] == "slurm"
+
+
+def test_serving_status_queries_the_backend(
+    swarm: DomynLLMSwarm, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caller can ask for live serving status without touching privates."""
+    from domyn_swarm.platform.protocols import ServingPhase, ServingStatus
+
+    seen: dict = {}
+
+    def fake_status(handle):
+        seen["handle"] = handle
+        return ServingStatus(phase=ServingPhase.RUNNING, url="http://lb:9003")
+
+    monkeypatch.setattr(swarm._deployment.serving, "status", fake_status)
+
+    result = swarm.serving_status()
+
+    assert result.phase is ServingPhase.RUNNING
+    assert seen["handle"] is swarm.serving_handle
+
+
+def test_serving_status_on_an_undeployed_swarm_is_unknown(
+    db_path: Path, slurm_cfg: DomynLLMSwarmConfig
+) -> None:
+    """Asking a never-deployed swarm for status is a question, not an assertion."""
+    from domyn_swarm.platform.protocols import ServingPhase
+
+    undeployed = DomynLLMSwarm(name="never-up", cfg=slurm_cfg)
+
+    assert undeployed.serving_status().phase is ServingPhase.UNKNOWN

--- a/tests/core/test_swarm_seams.py
+++ b/tests/core/test_swarm_seams.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+"""The public seams of DomynLLMSwarm: platform, status, rehydration, purity."""
+
+from pathlib import Path
+
+import pytest
+
+from domyn_swarm.config.slurm import SlurmConfig, SlurmEndpointConfig
+from domyn_swarm.config.swarm import DomynLLMSwarmConfig
+from domyn_swarm.core.state.db import make_session_factory
+from domyn_swarm.core.state.models import JobRecord, SwarmRecord
+from domyn_swarm.core.state.state_manager import SwarmStateManager
+from domyn_swarm.core.swarm import DomynLLMSwarm
+from domyn_swarm.platform.protocols import ServingHandle
+
+
+def _init_schema(db_path: Path) -> None:
+    """Create the swarm and job tables in a temporary SQLite file."""
+    session_factory = make_session_factory(db_path)
+    with session_factory() as s:
+        engine = s.get_bind()
+        SwarmRecord.__table__.create(bind=engine, checkfirst=True)
+        JobRecord.__table__.create(bind=engine, checkfirst=True)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point SwarmStateManager at a temporary SQLite DB with the schema created."""
+    path = tmp_path / SwarmStateManager.DB_NAME
+    monkeypatch.setattr(
+        SwarmStateManager, "_get_db_path", classmethod(lambda cls: path)
+    )
+    _init_schema(path)
+    return path
+
+
+@pytest.fixture
+def slurm_cfg(tmp_path: Path) -> DomynLLMSwarmConfig:
+    """A minimal valid Slurm config rooted in a temporary home directory."""
+    return DomynLLMSwarmConfig(
+        name="fake",
+        hf_home=".",
+        image="image",
+        model="Qwen/Qwen3-32B",
+        revision=None,
+        replicas=1,
+        gpus_per_node=1,
+        gpus_per_replica=1,
+        replicas_per_node=1,
+        nodes=1,
+        port=1000,
+        cpus_per_task=2,
+        mem_per_cpu="1GB",
+        wait_endpoint_s=1200,
+        home_directory=tmp_path,
+        backend=SlurmConfig(
+            type="slurm",
+            partition="partition",
+            account="account",
+            qos="qos",
+            requires_ray=False,
+            endpoint=SlurmEndpointConfig(
+                cpus_per_task=1,
+                nginx_image="/path/to/vllm.sif",
+                mem="1GB",
+                threads_per_core=1,
+                wall_time="24:00:00",
+                enable_proxy_buffering=True,
+                nginx_timeout="60s",
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def swarm(db_path: Path, slurm_cfg: DomynLLMSwarmConfig) -> DomynLLMSwarm:
+    """A deployed-looking swarm wired to the temporary state DB."""
+    return DomynLLMSwarm(
+        name="swarm",
+        cfg=slurm_cfg,
+        serving_handle=ServingHandle(
+            id="1234",
+            url="http://lb:9003",
+            meta={
+                "lb_jobid": 1234,
+                "jobid": 5678,
+                "lb_node": "lrdn4759",
+                "port": 9003,
+                "name": "swarm",
+            },
+        ),
+        endpoint="http://lb:9003",
+        delete_on_exit=True,
+    )
+
+
+def test_platform_is_public(swarm: DomynLLMSwarm) -> None:
+    """The platform is part of the public surface, not a private attribute."""
+    assert swarm.platform == "slurm"
+    assert not hasattr(swarm, "_platform")
+
+
+def test_saved_swarm_reports_its_platform_in_list_all(swarm: DomynLLMSwarm) -> None:
+    """Regression: `domyn-swarm swarm list` showed an empty backend column.
+
+    `_platform` was a PrivateAttr, so it never reached the persisted payload
+    that list_all() read it back out of.
+    """
+    swarm._state_mgr.save(deployment_name="swarm")
+
+    rows = SwarmStateManager.list_all()
+    row = next(r for r in rows if r["deployment_name"] == "swarm")
+
+    assert row["platform"] == "slurm"

--- a/tests/core/test_swarm_seams.py
+++ b/tests/core/test_swarm_seams.py
@@ -145,3 +145,74 @@ def test_serving_status_on_an_undeployed_swarm_is_unknown(
     undeployed = DomynLLMSwarm(name="never-up", cfg=slurm_cfg)
 
     assert undeployed.serving_status().phase is ServingPhase.UNKNOWN
+
+
+def test_from_record_builds_a_complete_swarm(swarm: DomynLLMSwarm) -> None:
+    """Rehydration produces a finished object, not one to be back-filled."""
+    swarm._state_mgr.save(deployment_name="swarm")
+
+    loaded = SwarmStateManager.load(deployment_name="swarm")
+
+    assert loaded.serving_handle is not None
+    assert loaded.serving_handle.id == "1234"
+    assert loaded.platform == "slurm"
+    # The compute backend was built from the handle, not left as a placeholder.
+    assert loaded._deployment.compute is not None
+    assert loaded._deployment.compute.lb_jobid == 1234
+    assert loaded._deployment.compute.lb_node == "lrdn4759"
+
+
+def test_state_manager_does_not_touch_swarm_internals() -> None:
+    """The persistence layer must not write private attributes of the swarm."""
+    import inspect
+
+    from domyn_swarm.core.state import state_manager
+
+    source = inspect.getsource(state_manager)
+
+    assert "swarm._deployment" not in source
+    assert "swarm._platform" not in source
+
+
+def test_adopt_attaches_a_handle_to_a_deployment(
+    db_path: Path, slurm_cfg: DomynLLMSwarmConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`adopt` is the public seam replacing a write to Deployment._handle.
+
+    Asserted through observable behaviour: a deployment with no handle reports
+    UNKNOWN, and one that has adopted a handle forwards it to the backend.
+    """
+    from domyn_swarm.platform.protocols import ServingPhase, ServingStatus
+
+    fresh = DomynLLMSwarm(name="adopter", cfg=slurm_cfg)
+    assert fresh._deployment.status().phase is ServingPhase.UNKNOWN
+
+    handle = ServingHandle(id="9999", url="http://other:9003", meta={"lb_jobid": 1})
+    seen: dict = {}
+
+    def fake_status(h):
+        seen["handle"] = h
+        return ServingStatus(phase=ServingPhase.RUNNING, url="http://other:9003")
+
+    monkeypatch.setattr(fresh._deployment.serving, "status", fake_status)
+
+    fresh._deployment.adopt(handle)
+
+    assert fresh._deployment.status().phase is ServingPhase.RUNNING
+    assert seen["handle"] is handle
+
+
+def test_from_record_rejects_an_incoherent_slurm_record(swarm: DomynLLMSwarm) -> None:
+    """A persisted Slurm handle without a jobid is rejected at rehydration.
+
+    The Slurm serving backend indexes ``handle.meta["jobid"]`` directly, so a
+    record missing it must fail loudly here rather than with a bare KeyError
+    from deep inside ``status()``. The check belongs to the plan, which owns
+    platform-specific knowledge; the swarm only asks it to run.
+    """
+    assert swarm.serving_handle is not None
+    swarm.serving_handle.meta["jobid"] = None
+    swarm._state_mgr.save(deployment_name="swarm")
+
+    with pytest.raises(ValueError, match="job IDs"):
+        SwarmStateManager.load(deployment_name="swarm")

--- a/tests/platform/test_http_probe.py
+++ b/tests/platform/test_http_probe.py
@@ -72,6 +72,7 @@ def test_wait_http_200_includes_token(monkeypatch):
         api_token = DummyToken()
         vllm_api_key = None
         singularityenv_vllm_api_key = None
+        resolved_api_token = DummyToken()
 
     monkeypatch.setattr("domyn_swarm.platform.http_probe.get_settings", lambda: DummySettings())
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -143,15 +143,13 @@ class TestSwarmStateManager:
     # Error cases around missing job metadata
     # --------------------------------------------------------------------- #
 
-    def test_load_null_jobid_does_not_raise(self, state_manager: SwarmStateManager) -> None:
-        """The plain (non-LB) job ID is irrelevant to the compute backend, so a
-        null value must not block loading as long as lb_jobid/lb_node are present.
-        """
+    def test_load_null_jobid(self, state_manager: SwarmStateManager) -> None:
+        """Null Job ID in serving_handle.meta should raise."""
         state_manager.swarm.serving_handle.meta["jobid"] = None  # type: ignore[union-attr]
         state_manager.save(deployment_name="fake")
 
-        swarm = SwarmStateManager.load(deployment_name="fake")
-        assert swarm._deployment.compute is not None  # type: ignore[attr-defined]
+        with pytest.raises(ValueError, match="job IDs"):
+            SwarmStateManager.load(deployment_name="fake")
 
     def test_load_null_lb_jobid(self, state_manager: SwarmStateManager) -> None:
         """Null LB Job ID in serving_handle.meta should raise."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -143,20 +143,22 @@ class TestSwarmStateManager:
     # Error cases around missing job metadata
     # --------------------------------------------------------------------- #
 
-    def test_load_null_jobid(self, state_manager: SwarmStateManager) -> None:
-        """Null Job ID in serving_handle.meta should raise."""
+    def test_load_null_jobid_does_not_raise(self, state_manager: SwarmStateManager) -> None:
+        """The plain (non-LB) job ID is irrelevant to the compute backend, so a
+        null value must not block loading as long as lb_jobid/lb_node are present.
+        """
         state_manager.swarm.serving_handle.meta["jobid"] = None  # type: ignore[union-attr]
         state_manager.save(deployment_name="fake")
 
-        with pytest.raises(ValueError, match="job IDs"):
-            SwarmStateManager.load(deployment_name="fake")
+        swarm = SwarmStateManager.load(deployment_name="fake")
+        assert swarm._deployment.compute is not None  # type: ignore[attr-defined]
 
     def test_load_null_lb_jobid(self, state_manager: SwarmStateManager) -> None:
         """Null LB Job ID in serving_handle.meta should raise."""
         state_manager.swarm.serving_handle.meta["lb_jobid"] = None  # type: ignore[union-attr]
         state_manager.save(deployment_name="fake")
 
-        with pytest.raises(ValueError, match="LB job info"):
+        with pytest.raises(RuntimeError, match="lb_jobid"):
             SwarmStateManager.load(deployment_name="fake")
 
     def test_load_null_lb_node(self, state_manager: SwarmStateManager) -> None:
@@ -164,7 +166,7 @@ class TestSwarmStateManager:
         state_manager.swarm.serving_handle.meta["lb_node"] = None  # type: ignore[union-attr]
         state_manager.save(deployment_name="fake")
 
-        with pytest.raises(ValueError, match="LB job info"):
+        with pytest.raises(RuntimeError, match="lb_node"):
             SwarmStateManager.load(deployment_name="fake")
 
     def test_load_unknown_job_raises(self, state_manager: SwarmStateManager) -> None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -8,6 +8,7 @@ import sqlite3
 
 import pytest
 
+from domyn_swarm.config.lepton import LeptonConfig
 from domyn_swarm.config.slurm import SlurmConfig, SlurmEndpointConfig
 from domyn_swarm.config.swarm import DomynLLMSwarmConfig
 from domyn_swarm.core.state.db import make_session_factory
@@ -112,6 +113,40 @@ class TestSwarmStateManager:
         # DomynLLMSwarm should attach its own SwarmStateManager as _state_mgr
         return swarm._state_mgr  # type: ignore[attr-defined]
 
+    @pytest.fixture
+    def lepton_swarm(self, db_path: Path) -> DomynLLMSwarm:
+        """Construct a Lepton-backed DomynLLMSwarm wired to the temporary DB.
+
+        Lepton serving handles carry no ``jobid``/``lb_jobid``/``lb_node`` keys
+        (those are Slurm-only concepts), so this fixture's ``serving_handle.meta``
+        deliberately omits them.
+        """
+        return DomynLLMSwarm(
+            name="lepton-swarm",
+            cfg=DomynLLMSwarmConfig(
+                name="fake-lepton",
+                image="image",
+                model="Qwen/Qwen3-32B",
+                revision=None,
+                replicas=1,
+                gpus_per_replica=1,
+                backend=LeptonConfig(
+                    type="lepton",
+                    workspace_id="ws-123",
+                ),
+            ),
+            serving_handle=ServingHandle(
+                id="lepton-endpoint",
+                url="https://lepton.example/v1",
+                meta=dict(
+                    name="lepton-swarm",
+                    workspace_id="ws-123",
+                ),
+            ),
+            endpoint="https://lepton.example/v1",
+            delete_on_exit=True,
+        )
+
     # --------------------------------------------------------------------- #
     # Basic path / save / load behaviour
     # --------------------------------------------------------------------- #
@@ -137,6 +172,28 @@ class TestSwarmStateManager:
         # Serving handle should be wired back
         assert swarm.serving_handle is not None
         # Compute backend should be attached
+        assert swarm._deployment.compute is not None  # type: ignore[attr-defined]
+
+    def test_load_lepton_without_jobid_does_not_raise(self, lepton_swarm: DomynLLMSwarm) -> None:
+        """Lepton handles have no jobid; load() must not apply the Slurm-only guard.
+
+        Regression test for the platform-specific guard in
+        ``SwarmStateManager.load()``: it must only reject missing job IDs for
+        Slurm swarms, and must pass Lepton swarms through unchanged even though
+        their serving handle has no ``jobid`` key at all.
+        """
+        state_mgr = lepton_swarm._state_mgr  # type: ignore[attr-defined]
+        assert "jobid" not in lepton_swarm.serving_handle.meta  # type: ignore[union-attr]
+        state_mgr.save(deployment_name="fake-lepton")
+
+        swarm = SwarmStateManager.load(deployment_name="fake-lepton")
+
+        assert isinstance(swarm, DomynLLMSwarm)
+        assert swarm._plan is not None  # type: ignore[attr-defined]
+        assert swarm._plan.platform == "lepton"  # type: ignore[attr-defined]
+        assert swarm.serving_handle is not None
+        assert swarm.serving_handle.url == "https://lepton.example/v1"
+        assert swarm.serving_handle.meta.get("workspace_id") == "ws-123"
         assert swarm._deployment.compute is not None  # type: ignore[attr-defined]
 
     # --------------------------------------------------------------------- #


### PR DESCRIPTION
# What does this PR do?

This PR straightens the core seams around swarm construction, deployment planning, persistence, and monitoring ahead of the 0.31 release.

## Highlights

- Moves compute-backend construction into `DeploymentPlan`.
  - Slurm builds its compute backend from the live serving handle.
  - Lepton continues using its plan-time backend.
  - Core and persistence code no longer branch on platform names.
- Replaces leaked private state with public seams:
  - `DomynLLMSwarm.platform`
  - `DomynLLMSwarm.serving_status()`
  - `DomynLLMSwarm.from_record()`
  - `Deployment.adopt()`
- Makes `DomynLLMSwarm` construction side-effect free.
  - Plans and deployments are created lazily.
  - Directory creation is explicit and idempotent.
  - Constructing a swarm no longer creates directories or imports a serving backend.
- Removes the parallel `load_monitor_view()` persistence path. Monitoring now uses the normal swarm-loading path.
- Reads settings at the point of use and centralizes API-token precedence in `Settings.resolved_api_token`.
- Fixes `domyn-swarm swarm list` showing an empty backend column.
- Adds regression coverage for Slurm and Lepton rehydration, compute-backend construction, settings refresh, public swarm seams, and constructor purity.

## Compatibility

This targets the breaking 0.31 release. Records written by v0.30 continue to load because `cfg.backend.type` remains the authoritative platform value. No database migration is required.

## Verification

- `uv run pre-commit run --show-diff-on-failure --color=always --all-files`
- `uv run pytest -q` — 1,000 passed, 3 skipped
- Coverage: 80%
- `uv run sphinx-build -W docs docs/_build/html`

## Before submitting

- [ ] Did you read the [contributor guidelines](https://github.com/igeniusai/domyn-swarm/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed or approved through a GitHub issue? Add a link if applicable.
- [x] Necessary tests were added.
- [x] API docstrings were updated and the documentation builds without warnings.