### PR TITLE
docs: revamp the README as a shop window, and self-host the coverage badge

### DIFF
--- a/.github/scripts/coverage_badge.py
+++ b/.github/scripts/coverage_badge.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn a Cobertura ``coverage.xml`` into a shields.io badge payload.
+
+The file this writes is published to the repository's ``badges`` branch and read
+by shields.io over raw.githubusercontent.com, which is why it has to be plain
+JSON at a stable path rather than anything served dynamically.
+
+The payload deliberately satisfies two shields formats at once:
+
+* the **endpoint** badge reads ``schemaVersion``/``label``/``message``/``color``,
+  so the colour is decided here and tracks the number;
+* the **dynamic JSON** badge reads the numeric ``coverage`` field via a query.
+
+Switching between the two is therefore a README edit, with no CI change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+# Descending floors, mirroring the colour scale shields uses for its own
+# coverage badges.
+_SCALE: tuple[tuple[float, str], ...] = (
+    (95, "brightgreen"),
+    (90, "green"),
+    (75, "yellowgreen"),
+    (60, "yellow"),
+    (40, "orange"),
+    (0, "red"),
+)
+
+
+def colour_for(percent: float) -> str:
+    """Return the shields colour name for a coverage percentage."""
+    for floor, colour in _SCALE:
+        if percent >= floor:
+            return colour
+    return "red"
+
+
+def percent_from(xml_path: Path) -> float:
+    """Read the overall line coverage percentage out of a Cobertura report."""
+    root = ET.parse(xml_path).getroot()
+    rate = root.get("line-rate")
+    if rate is None:
+        raise SystemExit(f"{xml_path}: no line-rate attribute; is this a Cobertura report?")
+    return round(float(rate) * 100, 1)
+
+
+def payload(percent: float) -> dict[str, object]:
+    """Build the badge document for both shields formats."""
+    shown = f"{percent:.0f}%" if float(percent).is_integer() else f"{percent}%"
+    return {
+        "schemaVersion": 1,
+        "label": "coverage",
+        "message": shown,
+        "color": colour_for(percent),
+        "coverage": percent,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("xml", type=Path, help="path to coverage.xml")
+    parser.add_argument("-o", "--output", type=Path, help="write JSON here instead of stdout")
+    args = parser.parse_args(argv)
+
+    doc = payload(percent_from(args.xml))
+    text = json.dumps(doc, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,66 @@ jobs:
           extra_args: --all-files
 
       - name: Run tests
-        run: uv run pytest -v
+        run: uv run pytest -v --cov-report=xml
+
+      # Only one version needs to feed the badge; 3.12 is the version the docs
+      # and the recommended install line use.
+      - name: Upload the coverage report
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          retention-days: 7
+
+  # The coverage badge is a JSON file on the `badges` branch, read by
+  # shields.io. Keeping it in this repository avoids depending on a third-party
+  # coverage service, and needs no secret beyond the built-in GITHUB_TOKEN.
+  coverage-badge:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'igeniusai'
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-xml
+
+      - name: Render the badge payload
+        run: python3 .github/scripts/coverage_badge.py coverage.xml -o badge.json && cat badge.json
+
+      # A dedicated orphan branch: it shares no history with main, so the badge
+      # commits never appear in the source history and cannot collide with it.
+      - name: Publish it to the badges branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          work=$(mktemp -d)
+          cp badge.json "$work/coverage.json"
+          cd "$work"
+          git init -q
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # A mixed reset seeds the index from the existing branch, so anything
+          # else already published there survives a commit that only stages
+          # coverage.json.
+          if git fetch -q --depth 1 origin badges 2>/dev/null; then
+            git reset -q FETCH_HEAD
+          fi
+          git add coverage.json
+          # Nothing to do when the percentage has not moved.
+          if git diff --cached --quiet; then
+            echo "coverage unchanged; leaving the badges branch alone"
+            exit 0
+          fi
+          pct=$(python3 -c 'import json;print(json.load(open("coverage.json"))["message"])')
+          git commit -qm "coverage: ${pct} at ${GITHUB_SHA:0:7}"
+          git push -q origin HEAD:badges
 
   build-dev-image:
     # Build/push dev images only for branch pushes from the main repo (not PRs from forks)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+security@domyn.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -1,140 +1,272 @@
-<p align="center">
-  <picture>
-      <source srcset="static/domyn-swarm-logo-white.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="static/domyn-swarm-logo-primary.svg" media="(prefers-color-scheme: light)">
-      <img src="static/domyn-swarm-logo-primary.svg" alt="domyn-swarm" height="100">
-   </picture>
-</p>
+<div align="center">
 
-> A simple, batteries‑included CLI and Python library for launching **LLM serving endpoints** and running **high‑throughput batch jobs** against them. First‑class support for **Slurm** (HPC) and **NVIDIA DGX Cloud Lepton**.
+<picture>
+  <source srcset="static/domyn-swarm-logo-white.svg" media="(prefers-color-scheme: dark)">
+  <source srcset="static/domyn-swarm-logo-primary.svg" media="(prefers-color-scheme: light)">
+  <img src="static/domyn-swarm-logo-primary.svg" alt="domyn-swarm" height="100">
+</picture>
 
-<p align="center">
-<a href="https://domynswarm.domyn.com/"><img src="https://img.shields.io/badge/docs-latest-blue" alt="Documentation"></a>
-<img src="https://github.com/igeniusai/domyn-swarm/actions/workflows/ci.yaml/badge.svg" alt="CI">
-<img src="https://img.shields.io/badge/python-3.10%7C3.11%7C3.12%7C3.13-brightgreen?style=flat&logoColor=green" alt="Python">
-<img src="https://img.shields.io/badge/License-Apache%202.0-blue" alt="License - Apache 2.0">
-<img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff">
-<img src="https://microsoft.github.io/pyright/img/pyright_badge.svg" alt="Pyright">
-</p>
+**Deploy LLMs and run resumable batch inference on Slurm and NVIDIA DGX Cloud Lepton.**
 
----
+domyn-swarm is a CLI and Python library that combines model deployment and batch processing in one
+workflow. vLLM handles inference; domyn-swarm manages replicas, load balancing, and job execution.
 
-## Why Domyn‑Swarm?
+[![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://domynswarm.domyn.com/)
+[![CI](https://github.com/igeniusai/domyn-swarm/actions/workflows/ci.yaml/badge.svg)](https://github.com/igeniusai/domyn-swarm/actions/workflows/ci.yaml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/igeniusai/domyn-swarm/badges/coverage.json)](https://github.com/igeniusai/domyn-swarm/actions/workflows/ci.yaml)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-brightgreen)](https://github.com/igeniusai/domyn-swarm/blob/main/pyproject.toml)
+[![License - Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue)](LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Pyright](https://microsoft.github.io/pyright/img/pyright_badge.svg)](https://github.com/microsoft/pyright)
 
-Domyn‑Swarm gives you a **single, consistent workflow** to stand up a **scalable
-LLM endpoint** (vLLM, OpenAI‑compatible), **submit jobs and scripts** that call it
-with **checkpointing, retries and bounded concurrency**, and **tear it all down**
-cleanly — the same way on HPC (Slurm) and in the cloud (Lepton).
+<a href="#quick-start">Quick start</a> •
+<a href="#write-your-own-job">Custom jobs</a> •
+<a href="#backends">Backends</a> •
+<a href="#documentation">Documentation</a> •
+<a href="CONTRIBUTING.md">Contributing</a>
 
-It's designed for **fast evaluation loops**, **robust batch inference**, and
-**easy backend extension**.
+</div>
 
 ---
 
-## Installation
+<table>
+<tr>
+<td width="50%" valign="top">
 
-**PyPI (once published):**
+### ⚡ Serve
+
+- **YAML configuration** for model and replica settings
+- **OpenAI-compatible endpoints** backed by vLLM
+- **Multiple replicas** behind a single load-balanced URL
+- **Lifecycle commands** to launch, inspect, and stop named swarms
+
+</td>
+<td width="50%" valign="top">
+
+### 🚀 Run
+
+- **Batch inference** over Parquet datasets
+- **Checkpointing and resume** for interrupted jobs
+- **Retries with backoff** and **bounded concurrency**
+- **Input sharding** for parallel job execution
+
+</td>
+</tr>
+</table>
+
+On Slurm, optional [Prometheus metrics and dashboards](https://domynswarm.domyn.com/latest/guides/metrics.html)
+show inference throughput, queue depth, and GPU utilization.
+
+---
+
+## Quick start
 
 > [!NOTE]
-> We still haven't published the package on PyPI, but it will soon be available
+> domyn-swarm is not yet published on PyPI. Install from the repository for now; `pip install domyn-swarm`
+> will work from the first published release.
 
 ```bash
-pip install domyn-swarm
+uv tool install --from git+https://github.com/igeniusai/domyn-swarm.git@v0.30.0 --python 3.12 domyn-swarm
+```
+
+<details>
+<summary>Extras and other install methods</summary>
+
+```bash
 # Optional extras
 pip install 'domyn-swarm[lepton]'   # NVIDIA DGX Cloud Lepton backend
 pip install 'domyn-swarm[polars]'   # Polars data backend
 pip install 'domyn-swarm[ray]'      # Ray Data backend
-# or everything
-pip install 'domyn-swarm[all]'
+pip install 'domyn-swarm[all]'      # everything
 ```
 
-**From source (GitHub):**
-
-```bash
-RELEASE=v0.30.0
-uv tool install --from git+ssh://git@github.com/igeniusai/domyn-swarm.git@$RELEASE --python 3.12 domyn-swarm
-```
-
-Full instructions, including `uv add`, editable installs and the Lepton
-`lep login` step, are in
+`uv add`, editable installs and the Lepton `lep login` step are covered in
 [Installation](https://domynswarm.domyn.com/latest/getting-started/installation.html).
+
+</details>
+
+**1. Describe the swarm**
+
+The [`examples/configs/`](examples/configs/) directory holds ready-made configurations. This one
+serves NVIDIA Nemotron-3-Super-120B-A12B across two replicas of four GPUs each, following the
+[vLLM recipe](https://recipes.vllm.ai/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16)
+([`nemotron_3_super.yaml`](examples/configs/nemotron_3_super.yaml)) — fill in the image paths,
+partition, account and QoS for your cluster:
+
+```yaml
+# NVIDIA Nemotron-3-Super-120B-A12B (BF16) — a ~120B latent-MoE with ~12B active
+# parameters. Serving flags follow https://recipes.vllm.ai/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+# The recipe's `--served-model-name` is deliberately omitted: jobs address the
+# endpoint by the `model` value below, so renaming the served model breaks them.
+model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+name: nemotron-3-super-120b
+revision: main
+gpus_per_replica: 4       # tensor-parallel size 4, one node on most clusters
+replicas: 2               # two independent replicas behind the load balancer
+image: "/path/to/vllm.sif"   # needs vLLM >= 0.17.1
+args: >-
+  --tensor-parallel-size 4
+  --kv-cache-dtype fp8
+  --max-model-len 262144
+  --trust-remote-code
+  --enable-auto-tool-choice
+  --tool-call-parser qwen3_xml
+  --reasoning-parser nemotron_v3
+env:
+  HF_HOME: /path/to/shared_hf_cache
+wait_endpoint_s: 3600
+backend:
+  type: slurm
+  partition: partition_name
+  account: account_name
+  qos: qos_name
+  endpoint:
+    port: 9001
+    cpus_per_task: 4
+    wall_time: "36:00:00"
+    nginx_image: "/path/to/nginx.sif"
+```
+
+**2. Launch it**
+
+`up` submits the replica and load-balancer jobs and returns once the endpoint answers a health check.
+Every swarm gets a unique name — the one in the config plus a short suffix — and `up` writes it to
+stdout so it can be captured:
+
+```console
+$ SWARM=$(domyn-swarm up -c examples/configs/nemotron_3_super.yaml)
+[08/31/26 11:56:44] INFO     Creating deployment nemotron-3-super-120b on slurm...
+                    INFO     Submitted replicas job 15427318 with command: sbatch --parsable …
+                    INFO     Submitted load balancer job 15427319 with command: sbatch --parsable …
+                    INFO     LB healthy → http://lrdn0431:9001/v1
+
+$ echo $SWARM
+nemotron-3-super-120b-01m1bq26m7
+```
+
+**3. Run a batch job**
+
+```console
+$ domyn-swarm job submit \
+    --name $SWARM \
+    --input examples/data/chat_completion.parquet \
+    --output results.parquet
+[MainThread] Checkpoint flushed 16 rows, new total: 16
+[MainThread] Checkpoint flushed 16 rows, new total: 32
+[MainThread] Checkpoint flushed 16 rows, new total: 48
+[MainThread] Checkpoint flushed 16 rows, new total: 64
+[MainThread] Checkpoint flushed 1 rows, new total: 65
+[MainThread] Processing all items in worker: 100%|██████████| 65/65 [01:12<00:00,  1.11s/sample]
+```
+
+This is the built-in chat-completion job reading the `messages` column. The example dataset has 65
+rows; checkpoints are flushed every 16 by default, so an interrupted run picks up from the last flush
+rather than starting over. Raising `replicas` spreads the same job across more of them, with the load
+balancer distributing requests.
+
+**4. Inspect it, then release it**
+
+```console
+$ domyn-swarm status $SWARM      # live panel: replica states, endpoint, recorded jobs
+
+$ domyn-swarm down -y $SWARM
+✅ Swarm nemotron-3-super-120b-01m1bq26m7 shutdown request sent.
+```
+
+The [Quickstart](https://domynswarm.domyn.com/latest/getting-started/quickstart.html) covers the same
+run step by step.
 
 ---
 
-## Quickstart
+## Write your own job
 
-```yaml
-# config.yaml
-model: "HuggingFaceTB/SmolLM3-3B-Base"
-gpus_per_replica: 16
-replicas: 2
-backend:
-  type: slurm
-  partition: partition_name    # your HPC partition
-  account: account_name        # your HPC account
-  qos: qos_name                # qos for cluster + jobs
+Subclass `SwarmJob` and implement `transform_items` to define how inputs are processed.
+The framework handles concurrency, retries, and checkpointing.
+
+```python
+from typing import Any
+
+from domyn_swarm.jobs import SwarmJob
+
+
+class SentimentJob(SwarmJob):
+    """Classify each prompt as positive, negative, or neutral."""
+
+    async def transform_items(self, items: list[Any]) -> list[str]:
+        results = []
+        for prompt in items:
+            resp = await self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "Reply only: positive, negative, or neutral."},
+                    {"role": "user", "content": prompt},
+                ],
+            )
+            results.append(resp.choices[0].message.content or "")
+        return results
 ```
 
-```bash
-# Launch replicas behind a load balancer, and wait until they answer
-domyn-swarm up -c config.yaml
+This example uses the swarm's configured client and writes labels to the default `results` column.
+See [Your first custom job](https://domynswarm.domyn.com/latest/getting-started/first-custom-job.html)
+for input and output requirements, import setup, and CLI submission.
 
-# Run a batch job against the endpoint: DataFrame in, DataFrame out
-domyn-swarm job submit \
-  --name my-swarm-name \
-  --input examples/data/chat_completion.parquet \
-  --output results.parquet
+Built-in jobs cover chat completion, multi-turn conversations, perplexity, and translation.
+See the [Jobs API reference](https://domynswarm.domyn.com/latest/reference/api/jobs.html).
 
-# Check on it
-domyn-swarm status my-swarm-name
+---
 
-# Remove everything it created
-domyn-swarm down my-swarm-name
-```
+## Backends
 
-The [Quickstart](https://domynswarm.domyn.com/latest/getting-started/quickstart.html)
-walks through the same run with an explanation of each step.
+The same core commands—`up`, `job submit`, `status`, and `down`—are available on both platforms:
+
+- **Slurm** — included in the base installation. See [Slurm setup](https://domynswarm.domyn.com/latest/guides/slurm.html).
+- **NVIDIA DGX Cloud Lepton** — requires the `lepton` extra and workspace credentials. See [Lepton setup](https://domynswarm.domyn.com/latest/guides/lepton.html).
+
+Job input and output support **pandas** (default), **polars**, and **Ray Data**.
+See [Choosing a data backend](https://domynswarm.domyn.com/latest/guides/data-backends.html).
+
+To add support for another platform, see [Implementing a backend](https://domynswarm.domyn.com/latest/guides/implementing-a-backend.html).
 
 ---
 
 ## Documentation
 
-The full documentation lives at
-**[domynswarm.domyn.com](https://domynswarm.domyn.com/)**.
+The full documentation is published at **[domynswarm.domyn.com](https://domynswarm.domyn.com/)**.
 
-* [Getting started](https://domynswarm.domyn.com/latest/getting-started/index.html)
-  — install, launch a swarm, write your first custom job
-* [Guides](https://domynswarm.domyn.com/latest/guides/index.html)
-  — Slurm and Lepton, submitting jobs, checkpointing, sharding, data backends,
-  swarm state, monitoring
-* [Concepts](https://domynswarm.domyn.com/latest/concepts/index.html)
-  — architecture, the backend protocols, the `SwarmJob` lifecycle, configuration
-  precedence
-* Reference, generated from the source on every build —
-  [CLI](https://domynswarm.domyn.com/latest/reference/cli.html),
-  [Configuration](https://domynswarm.domyn.com/latest/reference/configuration.html),
-  [Environment variables](https://domynswarm.domyn.com/latest/reference/environment.html),
-  [Python API](https://domynswarm.domyn.com/latest/reference/api/index.html)
+| | |
+| --- | --- |
+| [Getting started](https://domynswarm.domyn.com/latest/getting-started/index.html) | install, launch a swarm, write your first custom job |
+| [Guides](https://domynswarm.domyn.com/latest/guides/index.html) | Slurm and Lepton, checkpointing, sharding, data backends, monitoring |
+| [Concepts](https://domynswarm.domyn.com/latest/concepts/index.html) | architecture, backend protocols, the `SwarmJob` lifecycle, configuration |
+| [Reference](https://domynswarm.domyn.com/latest/reference/index.html) | CLI, configuration, environment variables and Python API — generated from source |
 
 ---
 
 ## Contributing
 
-We welcome issues and PRs! Please see:
-
-* `CONTRIBUTING.md` — how to propose changes, coding style, DCO/CLA (as applicable)
-
----
+Issues and pull requests are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers the development
+setup, coding style and commit conventions; participation is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md). To report a vulnerability, follow our
+[security policy](SECURITY.md).
 
 ## License
 
-Licensed under the **Apache License, Version 2.0**. See `LICENSE` and `NOTICE`.
+Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
----
+## Citation
+
+```bibtex
+@software{domyn_swarm,
+  author  = {D'Ambrosio, Federico and Rognoni, Alessandro},
+  title   = {domyn-swarm: LLM serving endpoints and high-throughput batch jobs on Slurm and DGX Cloud Lepton},
+  year     = {2026},
+  url     = {https://github.com/igeniusai/domyn-swarm},
+  license = {Apache-2.0}
+}
+```
 
 ## Acknowledgements
 
-* Built on **vLLM** and **Ray** (Apache‑2.0)
-* Optional **NVIDIA DGX Cloud Lepton** integration via the Lepton SDK
-
-Happy swarming! 🚀
+Built on [vLLM](https://github.com/vllm-project/vllm) and [Ray](https://github.com/ray-project/ray),
+with optional support for [NVIDIA DGX Cloud Lepton](https://www.nvidia.com/en-us/data-center/dgx-cloud-lepton/)
+through the Lepton SDK.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security vulnerabilities to **security@domyn.com**.
+
+Please do not open a public GitHub issue, discussion or pull request for a
+security report.
+
+Include whatever you have:
+
+- the version or commit affected
+- the kind of issue — credential exposure, remote code execution, privilege
+  escalation, denial of service, and so on
+- steps to reproduce, and a proof of concept if you have one
+- the impact, and how an attacker would reach it
+
+We aim to acknowledge reports within five working days and will keep you
+updated while we investigate. When a fix ships we will credit you in the
+release notes unless you would rather we did not.
+
+## Supported versions
+
+domyn-swarm is pre-1.0 and under active development. Security fixes land on
+`main` and in the next release; we do not backport them to earlier tags.
+
+## Scope
+
+domyn-swarm launches containers and submits jobs on infrastructure you control.
+In scope: how domyn-swarm itself handles credentials and API tokens, what it
+writes into generated job scripts and configuration, and how it submits work to
+a backend.
+
+Vulnerabilities in the components it drives — Slurm, Singularity/Apptainer,
+vLLM, Ray, NVIDIA DGX Cloud Lepton — belong to those projects and should go to
+their own security contacts.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,8 +12,9 @@ config's `backend` section changes, as described in
 ```yaml
 # config.yaml
 model: "HuggingFaceTB/SmolLM3-3B-Base"
-gpus_per_replica: 16
-replicas: 2
+name: smollm3
+gpus_per_replica: 4
+replicas: 4
 backend:
   type: slurm
   partition: partition_name    # your HPC partition

--- a/examples/configs/nemotron_3_super.yaml
+++ b/examples/configs/nemotron_3_super.yaml
@@ -1,0 +1,31 @@
+# NVIDIA Nemotron-3-Super-120B-A12B (BF16) — a ~120B latent-MoE with ~12B active
+# parameters. Serving flags follow https://recipes.vllm.ai/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+# The recipe's `--served-model-name` is deliberately omitted: jobs address the
+# endpoint by the `model` value below, so renaming the served model breaks them.
+model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+name: nemotron-3-super-120b
+revision: main
+gpus_per_replica: 4       # tensor-parallel size 4, one node on most clusters
+replicas: 2               # two independent replicas behind the load balancer
+image: "/path/to/vllm.sif"   # needs vLLM >= 0.17.1
+args: >-
+  --tensor-parallel-size 4
+  --kv-cache-dtype fp8
+  --max-model-len 262144
+  --trust-remote-code
+  --enable-auto-tool-choice
+  --tool-call-parser qwen3_xml
+  --reasoning-parser nemotron_v3
+env:
+  HF_HOME: /path/to/shared_hf_cache
+wait_endpoint_s: 3600
+backend:
+  type: slurm
+  partition: partition_name
+  account: account_name
+  qos: qos_name
+  endpoint:
+    port: 9001
+    cpus_per_task: 4
+    wall_time: "36:00:00"
+    nginx_image: "/path/to/nginx.sif"

--- a/tests/test_coverage_badge.py
+++ b/tests/test_coverage_badge.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the CI helper that renders the coverage badge payload.
+
+The script lives under ``.github/scripts`` rather than in the package, because it
+is only ever run by the workflow, so it is loaded here by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "coverage_badge.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("coverage_badge", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+badge = _load()
+
+
+@pytest.mark.parametrize(
+    ("percent", "expected"),
+    [
+        (0, "red"),
+        (39.9, "red"),
+        (40, "orange"),
+        (59.9, "orange"),
+        (60, "yellow"),
+        (74.9, "yellow"),
+        (75, "yellowgreen"),
+        (89.9, "yellowgreen"),
+        (90, "green"),
+        (94.9, "green"),
+        (95, "brightgreen"),
+        (100, "brightgreen"),
+    ],
+)
+def test_colour_boundaries(percent, expected):
+    assert badge.colour_for(percent) == expected
+
+
+def test_percent_read_from_cobertura(tmp_path):
+    xml = tmp_path / "coverage.xml"
+    xml.write_text('<?xml version="1.0" ?><coverage line-rate="0.8012"></coverage>')
+    assert badge.percent_from(xml) == 80.1
+
+
+def test_missing_line_rate_is_an_error(tmp_path):
+    xml = tmp_path / "coverage.xml"
+    xml.write_text('<?xml version="1.0" ?><coverage></coverage>')
+    with pytest.raises(SystemExit):
+        badge.percent_from(xml)
+
+
+def test_payload_serves_both_shields_formats():
+    doc = badge.payload(80.1)
+    # endpoint badge
+    assert doc["schemaVersion"] == 1
+    assert doc["label"] == "coverage"
+    assert doc["message"] == "80.1%"
+    assert doc["color"] == "yellowgreen"
+    # dynamic JSON badge reads the bare number
+    assert doc["coverage"] == 80.1
+
+
+def test_whole_percentages_drop_the_decimal():
+    assert badge.payload(80.0)["message"] == "80%"
+
+
+def test_cli_writes_a_file(tmp_path):
+    xml = tmp_path / "coverage.xml"
+    xml.write_text('<?xml version="1.0" ?><coverage line-rate="0.5"></coverage>')
+    out = tmp_path / "badge.json"
+    assert badge.main([str(xml), "-o", str(out)]) == 0
+    assert json.loads(out.read_text())["message"] == "50%"


### PR DESCRIPTION
Rewrites the README as an entry point to [the documentation site](https://domynswarm.domyn.com/) rather than a manual, and adds the governance and CI pieces it relies on.

