### PR TITLE
feat(slurm): add support for job requeueing configuration and handling

### DIFF
--- a/docs/guides/slurm.md
+++ b/docs/guides/slurm.md
@@ -137,6 +137,22 @@ the deployment needs it.
 END and FAIL notifications. The load-balancer job is configured separately under
 `backend.endpoint`, including its own optional `qos` override.
 
+`backend.requeue` (default `true`) emits `#SBATCH --requeue`, so replica jobs
+come back after a node failure or preemption, and lets the Ray head ask Slurm
+for a requeue when the cluster dies. Some sites forbid requeueing outright — set
+it to `false` there:
+
+```yaml
+backend:
+  type: slurm
+  requeue: false
+```
+
+The directive is then omitted and a Ray head that loses its cluster exits
+non-zero instead of calling `scontrol requeue`, so the replica stays down rather
+than restarting. Since this is a property of the site rather than of one
+deployment, it also belongs in `defaults.yaml` as `slurm.requeue`.
+
 Full field list: [Configuration](../reference/configuration.md).
 
 ## Shutting down

--- a/src/domyn_swarm/cli/init.py
+++ b/src/domyn_swarm/cli/init.py
@@ -157,6 +157,10 @@ def _configure_slurm_defaults(existing: dict[str, Any]) -> dict[str, Any]:
         default=_get(existing, f"{base}.qos", ""),
         allow_empty=True,
     )
+    requeue = _yesno(
+        "Does this cluster allow requeueing jobs (#SBATCH --requeue)?",
+        default=bool(_get(existing, f"{base}.requeue", True)),
+    )
     nginx_image = _prompt_str(
         "Path to Nginx image (Singularity/Container)",
         default=_get(existing, f"{base}.nginx_image", ""),
@@ -203,6 +207,7 @@ def _configure_slurm_defaults(existing: dict[str, Any]) -> dict[str, Any]:
     if qos.strip():
         _set(out, f"{base}.qos", qos)
     _set(out, f"{base}.account", account)
+    _set(out, f"{base}.requeue", requeue)
     _set(out, f"{base_endpoint}.nginx_image", nginx_image)
     _set(out, f"{base_endpoint}.port", port)
     _set(out, f"{base_endpoint}.poll_interval", poll)

--- a/src/domyn_swarm/config/slurm.py
+++ b/src/domyn_swarm/config/slurm.py
@@ -363,6 +363,15 @@ class SlurmConfig(BaseModel):
         default="36:00:00",
         description="Overall Slurm wall-clock limit for the allocation.",
     )
+    requeue: bool = Field(
+        default_factory=default_for("slurm.requeue", True),
+        description=(
+            "Emit `#SBATCH --requeue` so replica jobs may be requeued after a "
+            "node failure or preemption, and let the Ray head ask for a requeue "
+            "when the cluster dies. Turn it off on sites that forbid requeueing; "
+            "a failed replica then stays down instead of coming back."
+        ),
+    )
     exclude_nodes: str | None = Field(
         default=None,
         description=("Nodes to exclude, passed through to Slurm, e.g. `node[001-004]`."),

--- a/src/domyn_swarm/templates/_swarm_common.sh.j2
+++ b/src/domyn_swarm/templates/_swarm_common.sh.j2
@@ -16,7 +16,9 @@
 #SBATCH --cpus-per-task={{ cfg.cpus_per_task }}
 #SBATCH --mem=0
 #SBATCH --time={{ cfg.backend.time_limit }}
+{% if cfg.backend.requeue %}
 #SBATCH --requeue
+{% endif %}
 {% if cfg.backend.exclude_nodes %}
 #SBATCH --exclude={{ cfg.backend.exclude_nodes }}
 {% endif %}

--- a/src/domyn_swarm/templates/llm_swarm_ray.sh.j2
+++ b/src/domyn_swarm/templates/llm_swarm_ray.sh.j2
@@ -5,6 +5,12 @@
 ###############################################################################
 
 requeue_this_job() {
+{% if not cfg.backend.requeue %}
+  # Requeueing is disabled for this deployment (backend.requeue=false), e.g.
+  # because the site forbids it. Fail the job instead of asking for a requeue.
+  echo "[head] requeue disabled (backend.requeue=false), failing the job instead" >&2
+  exit 1
+{% else %}
   # Requeue *this* Slurm job or array element.
   #
   # - For arrays: requeues <array_job_id>_<task_id>
@@ -34,6 +40,7 @@ requeue_this_job() {
     echo "[head] scontrol requeue failed for ${jid}, exiting 1" >&2
     exit 1
   fi
+{% endif %}
 }
 
 echo "[multi-node] Running $REPLICAS replicas on $SLURM_JOB_NUM_NODES nodes with $GPUS_PER_REPLICA GPU(s) each..."
@@ -295,7 +302,7 @@ consec_fail=0
 
 trap 'echo "[batch] caught SIGTERM → shutting down"; exit 0' SIGTERM
 
-echo "[head] entering Ray + vLLM health loop (requeue='on')"
+echo "[head] entering Ray + vLLM health loop (requeue='{{ 'on' if cfg.backend.requeue else 'off' }}')"
 
 while true; do
   # 0) Check if watchdog died with a special exit code

--- a/tests/backends/test_llm_swarm_ray_template.py
+++ b/tests/backends/test_llm_swarm_ray_template.py
@@ -11,7 +11,7 @@ from domyn_swarm.config.slurm import GpuExporterConfig
 TPL_DIR = Path("src/domyn_swarm/templates")
 
 
-def _cfg(mon_enabled, gpu_enabled, ray_metrics=None):
+def _cfg(mon_enabled, gpu_enabled, ray_metrics=None, requeue=True):
     """Build a minimal config-like object for rendering llm_swarm_ray.sh.j2."""
     gx = GpuExporterConfig(enabled=gpu_enabled)
     mon = SimpleNamespace(
@@ -27,6 +27,7 @@ def _cfg(mon_enabled, gpu_enabled, ray_metrics=None):
         qos="q",
         partition="p",
         time_limit="1:00:00",
+        requeue=requeue,
         preamble=[],
         modules=[],
         exclude_nodes=None,
@@ -119,3 +120,21 @@ def test_ray_metrics_absent_when_disabled():
     out = _render(cfg)
     assert "--metrics-export-port" not in out
     assert "ray-$(hostname).target" not in out
+
+
+def test_ray_requeue_enabled_asks_slurm_to_requeue():
+    out = _render(_cfg(mon_enabled=False, gpu_enabled=False, requeue=True))
+
+    assert "#SBATCH --requeue" in out
+    assert "scontrol requeue" in out
+    assert "requeue='on'" in out
+
+
+def test_ray_requeue_disabled_fails_instead_of_requeueing():
+    """With requeueing off, the head must never shell out to `scontrol requeue`."""
+    out = _render(_cfg(mon_enabled=False, gpu_enabled=False, requeue=False))
+
+    assert "#SBATCH --requeue" not in out
+    assert "scontrol requeue" not in out
+    assert "requeue disabled (backend.requeue=false)" in out
+    assert "requeue='off'" in out

--- a/tests/backends/test_llm_swarm_template.py
+++ b/tests/backends/test_llm_swarm_template.py
@@ -11,7 +11,7 @@ from domyn_swarm.config.slurm import GpuExporterConfig
 TPL_DIR = Path("src/domyn_swarm/templates")
 
 
-def _cfg(gpu_enabled, kind="nvidia_smi"):
+def _cfg(gpu_enabled, kind="nvidia_smi", requeue=True):
     """Build a minimal config-like object exposing the real GpuExporterConfig methods."""
     gx = GpuExporterConfig(enabled=gpu_enabled, kind=kind)
     mon = SimpleNamespace(enabled=True, mode="binary", gpu_exporter=gx)
@@ -23,6 +23,7 @@ def _cfg(gpu_enabled, kind="nvidia_smi"):
         qos="q",
         partition="p",
         time_limit="1:00:00",
+        requeue=requeue,
         preamble=[],
         modules=[],
         exclude_nodes=None,
@@ -101,3 +102,12 @@ def test_watchdog_is_not_launched_when_disabled():
     # The script stays bind-mounted (harmless); what matters is that it is not invoked.
     assert "python3 /opt/watchdog.py" not in out
     assert "vllm serve" in out, "the server itself must still start"
+
+
+def test_requeue_directive_present_when_enabled():
+    assert "#SBATCH --requeue" in _render(_cfg(False, requeue=True))
+
+
+def test_requeue_directive_absent_when_disabled():
+    """Sites that forbid requeueing must not get the directive at all."""
+    assert "#SBATCH --requeue" not in _render(_cfg(False, requeue=False))

--- a/tests/backends/test_template_split_parity.py
+++ b/tests/backends/test_template_split_parity.py
@@ -35,6 +35,7 @@ def _cfg(requires_ray: bool):
         qos="q",
         partition="p",
         time_limit="1:00:00",
+        requeue=True,
         preamble=[],
         modules=[],
         exclude_nodes=None,

--- a/tests/cli/test_init_defaults.py
+++ b/tests/cli/test_init_defaults.py
@@ -116,7 +116,7 @@ def test_yesno_passthrough(monkeypatch):
 
 def test_configure_slurm_defaults_sets_expected_fields(monkeypatch):
     # Order of prompts in _configure_slurm_defaults:
-    # image, partition, account, qos, nginx_image,
+    # image, partition, account, qos, requeue(confirm), nginx_image,
     # port, poll, cpus, mem, tpc, wall, proxy_buf(confirm), nginx_timeout
     prompt_answers = iter(
         [
@@ -139,7 +139,7 @@ def test_configure_slurm_defaults_sets_expected_fields(monkeypatch):
         # default is sometimes str(int) or string; we ignore it here
         return next(prompt_answers)
 
-    # confirm only used for proxy buffering in this flow
+    # confirm is used for requeue and proxy buffering in this flow
     monkeypatch.setattr(mod.typer, "prompt", fake_prompt)
     monkeypatch.setattr(mod.typer, "confirm", lambda label, default=True: True)
 
@@ -150,6 +150,7 @@ def test_configure_slurm_defaults_sets_expected_fields(monkeypatch):
     assert out["slurm"]["partition"] == "p"
     assert out["slurm"]["account"] == "acc"
     assert "qos" not in out.get("slurm", {})
+    assert out["slurm"]["requeue"] is True
 
     ep = out["slurm"]["endpoint"]
     assert ep["nginx_image"] == "nginx.sif"

--- a/tests/config/test_swarm_config.py
+++ b/tests/config/test_swarm_config.py
@@ -173,3 +173,19 @@ def test_ray_metrics_explicit_true_respected_on_non_ray():
     )
     assert cfg.backend.requires_ray is False
     assert cfg.backend.endpoint.monitoring.ray_metrics.enabled is True
+
+
+def test_requeue_defaults_to_enabled():
+    cfg = _cfg(gpus_per_replica=1, gpus_per_node=4, replicas=2)
+    assert cfg.backend.requeue is True
+
+
+def test_requeue_can_be_disabled():
+    """Sites that forbid `--requeue` opt out in YAML."""
+    cfg = _cfg(
+        gpus_per_replica=1,
+        gpus_per_node=4,
+        replicas=2,
+        backend_extra={"requeue": False},
+    )
+    assert cfg.backend.requeue is False


### PR DESCRIPTION
# What does this PR do?

Adds support for job requeueing configuration and handling, which is not supported on some sites and it was assumed to be always available by Domyn Swarm.