### PR TITLE
feat(slurm): add support for site-specific bind mounts in configuration

### DIFF
--- a/docs/guides/slurm.md
+++ b/docs/guides/slurm.md
@@ -77,6 +77,36 @@ instance a missing host path or an invalid option. For the full bind syntax see
 [Apptainer](https://apptainer.org/docs/user/main/bind_paths_and_mounts.html) or
 [SingularityCE](https://docs.sylabs.io/guides/latest/user-guide/bind_paths_and_mounts.html).
 
+## Site mounts
+
+Some clusters need host paths bound into every container for the software stack
+they provide through `module load` — on CINECA Leonardo, for instance,
+`/leonardo/prod/opt`. Those paths belong to the site, not to a deployment, so
+they go in `backend.system_mounts`, ideally in the site
+[defaults file](../reference/configuration.md) rather than in each config:
+
+```yaml
+# defaults.yaml
+slurm:
+  system_mounts:
+    - /leonardo/prod/opt
+```
+
+```yaml
+# or per deployment
+backend:
+  type: slurm
+  system_mounts:
+    - /leonardo/prod/opt
+```
+
+The syntax is the same as `backend.mounts`, with one difference: an entry is
+bound only when its host path exists on the node, and otherwise skipped with a
+warning in the job log. That way a config carried from one cluster to another
+does not fail every replica on a bind that only makes sense at the original
+site. The interconnect device directory `/dev/infiniband` is treated the same
+way, with no configuration needed.
+
 ## Modules and sbatch preamble
 
 Two fields inject site-specific setup into the generated cluster script:

--- a/src/domyn_swarm/cli/init.py
+++ b/src/domyn_swarm/cli/init.py
@@ -161,6 +161,12 @@ def _configure_slurm_defaults(existing: dict[str, Any]) -> dict[str, Any]:
         "Does this cluster allow requeueing jobs (#SBATCH --requeue)?",
         default=bool(_get(existing, f"{base}.requeue", True)),
     )
+    system_mounts = _prompt_str(
+        "Site-specific bind mounts for the containers, comma-separated "
+        "(e.g. /leonardo/prod/opt); leave empty for none",
+        default=",".join(_get(existing, f"{base}.system_mounts", []) or []),
+        allow_empty=True,
+    )
     nginx_image = _prompt_str(
         "Path to Nginx image (Singularity/Container)",
         default=_get(existing, f"{base}.nginx_image", ""),
@@ -208,6 +214,9 @@ def _configure_slurm_defaults(existing: dict[str, Any]) -> dict[str, Any]:
         _set(out, f"{base}.qos", qos)
     _set(out, f"{base}.account", account)
     _set(out, f"{base}.requeue", requeue)
+    mount_list = [m.strip() for m in system_mounts.split(",") if m.strip()]
+    if mount_list:
+        _set(out, f"{base}.system_mounts", mount_list)
     _set(out, f"{base_endpoint}.nginx_image", nginx_image)
     _set(out, f"{base_endpoint}.port", port)
     _set(out, f"{base_endpoint}.poll_interval", poll)

--- a/src/domyn_swarm/config/slurm.py
+++ b/src/domyn_swarm/config/slurm.py
@@ -411,14 +411,29 @@ class SlurmConfig(BaseModel):
         ),
     )
 
-    @field_validator("mounts")
+    system_mounts: list[str] = Field(
+        default_factory=default_for("slurm.system_mounts", []),
+        description=(
+            "Site-specific host paths the containers need, such as the cluster's "
+            "software stack or its interconnect devices (e.g. '/leonardo/prod/opt' "
+            "on CINECA Leonardo). Same syntax as `mounts`, but each entry is bound "
+            "only when its host path exists on the node, so a path belonging to "
+            "another site is skipped with a warning instead of failing the job. "
+            "Belongs in the site `defaults.yaml` under `slurm.system_mounts` rather "
+            "than in a per-deployment config."
+        ),
+    )
+
+    @field_validator("mounts", "system_mounts")
     @classmethod
     def _validate_mounts(cls, value: list[str]) -> list[str]:
         """Validate the format of each bind mount specification.
 
         Checks that every entry is non-empty, has at most three colon-separated
         segments (source[:dest[:opts]]), and uses an absolute source path. Host
-        path existence is intentionally not checked here.
+        path existence is intentionally not checked here: for `mounts` the
+        container runtime reports it, and `system_mounts` are checked on the node
+        at launch time.
 
         Args:
             value: The list of mount specifications.

--- a/src/domyn_swarm/templates/_swarm_common.sh.j2
+++ b/src/domyn_swarm/templates/_swarm_common.sh.j2
@@ -91,7 +91,26 @@ echo "🟢 Allocation: $SLURM_JOB_NUM_NODES nodes → head=$HEAD_NODE workers=${
 
 # Mount configuration
 LOCAL_RAY_LOGS="$TMPDIR/ray_tmp"
-export MOUNTS="$HF_HOME,/sys,/dev/infiniband,/leonardo/prod/opt/,$HOME,$SWARM_DIR,{{ watchdog_script_path }}:/opt/watchdog.py"
+export MOUNTS="$HF_HOME,/sys,$HOME,$SWARM_DIR,{{ watchdog_script_path }}:/opt/watchdog.py"
+
+# Site-specific binds (interconnect devices, the cluster software stack, ...) are
+# added only when the host path exists on this node, so a path configured for a
+# different site is skipped instead of failing the whole job.
+add_optional_mount() {
+  local spec="$1"
+  local src="${spec%%:*}"
+  if [ -e "$src" ]; then
+    MOUNTS="$MOUNTS,$spec"
+  else
+    echo "⚠️  skipping bind mount '$spec': '$src' does not exist on $(hostname)"
+  fi
+}
+
+add_optional_mount /dev/infiniband
+# System mounts (from backend.system_mounts in the YAML config or defaults.yaml)
+{% for mount in cfg.backend.system_mounts | default([], true) %}
+add_optional_mount "{{ mount }}"
+{% endfor %}
 {% if is_folder(cfg.model) and path_exists(cfg.model) %}
 MOUNTS=$MOUNTS,{{ cfg.model }}
 {% endif %}

--- a/tests/backends/fixtures/llm_swarm_baseline_novray.txt
+++ b/tests/backends/fixtures/llm_swarm_baseline_novray.txt
@@ -65,7 +65,23 @@ echo "🟢 Allocation: $SLURM_JOB_NUM_NODES nodes → head=$HEAD_NODE workers=${
 
 # Mount configuration
 LOCAL_RAY_LOGS="$TMPDIR/ray_tmp"
-export MOUNTS="$HF_HOME,/sys,/dev/infiniband,/leonardo/prod/opt/,$HOME,$SWARM_DIR,/w.py:/opt/watchdog.py"
+export MOUNTS="$HF_HOME,/sys,$HOME,$SWARM_DIR,/w.py:/opt/watchdog.py"
+
+# Site-specific binds (interconnect devices, the cluster software stack, ...) are
+# added only when the host path exists on this node, so a path configured for a
+# different site is skipped instead of failing the whole job.
+add_optional_mount() {
+  local spec="$1"
+  local src="${spec%%:*}"
+  if [ -e "$src" ]; then
+    MOUNTS="$MOUNTS,$spec"
+  else
+    echo "⚠️  skipping bind mount '$spec': '$src' does not exist on $(hostname)"
+  fi
+}
+
+add_optional_mount /dev/infiniband
+# System mounts (from backend.system_mounts in the YAML config or defaults.yaml)
 MOUNTS=$MOUNTS,m
 
 # User-defined extra mounts (from backend.mounts in the YAML config)

--- a/tests/backends/fixtures/llm_swarm_baseline_ray.txt
+++ b/tests/backends/fixtures/llm_swarm_baseline_ray.txt
@@ -63,7 +63,23 @@ echo "🟢 Allocation: $SLURM_JOB_NUM_NODES nodes → head=$HEAD_NODE workers=${
 
 # Mount configuration
 LOCAL_RAY_LOGS="$TMPDIR/ray_tmp"
-export MOUNTS="$HF_HOME,/sys,/dev/infiniband,/leonardo/prod/opt/,$HOME,$SWARM_DIR,/w.py:/opt/watchdog.py"
+export MOUNTS="$HF_HOME,/sys,$HOME,$SWARM_DIR,/w.py:/opt/watchdog.py"
+
+# Site-specific binds (interconnect devices, the cluster software stack, ...) are
+# added only when the host path exists on this node, so a path configured for a
+# different site is skipped instead of failing the whole job.
+add_optional_mount() {
+  local spec="$1"
+  local src="${spec%%:*}"
+  if [ -e "$src" ]; then
+    MOUNTS="$MOUNTS,$spec"
+  else
+    echo "⚠️  skipping bind mount '$spec': '$src' does not exist on $(hostname)"
+  fi
+}
+
+add_optional_mount /dev/infiniband
+# System mounts (from backend.system_mounts in the YAML config or defaults.yaml)
 MOUNTS=$MOUNTS,m
 
 # User-defined extra mounts (from backend.mounts in the YAML config)

--- a/tests/backends/test_slurm_mounts.py
+++ b/tests/backends/test_slurm_mounts.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+import subprocess
 
 import jinja2
 import pytest
@@ -37,7 +38,7 @@ def _render_template(cfg) -> str:
     )
 
 
-def _make_cfg(mounts):
+def _make_cfg(mounts, system_mounts=None):
     from domyn_swarm.config.swarm import DomynLLMSwarmConfig
 
     return DomynLLMSwarmConfig(
@@ -51,6 +52,7 @@ def _make_cfg(mounts):
             account="test_account",
             qos="test_qos",
             mounts=mounts,
+            system_mounts=system_mounts or [],
             endpoint=SlurmEndpointConfig(nginx_image="/path/to/nginx.sif"),
         ).model_dump(),
     )
@@ -107,3 +109,66 @@ def test_empty_mount_entry_rejected():
 def test_too_many_colon_segments_rejected():
     with pytest.raises(ValueError):
         _slurm_config(mounts=["/a:/b:ro:extra"])
+
+
+def test_system_mounts_rendered_as_existence_checked_binds():
+    cfg = _make_cfg([], system_mounts=["/opt/site/stack", "/host/lib:/usr/local/lib:ro"])
+    rendered = _render_template(cfg)
+    assert 'add_optional_mount "/opt/site/stack"' in rendered
+    assert 'add_optional_mount "/host/lib:/usr/local/lib:ro"' in rendered
+
+
+def test_no_site_specific_path_hardcoded_in_templates():
+    """No cluster-specific path may live in the shipped templates."""
+    template_dir = Path(domyn_swarm.__file__).resolve().parent / "templates"
+    for template in template_dir.glob("*.j2"):
+        assert "/leonardo" not in template.read_text(), f"site path hardcoded in {template.name}"
+
+
+def test_base_mounts_have_no_system_mounts_by_default():
+    cfg = _make_cfg([])
+    rendered = _render_template(cfg)
+    # Only the built-in optional bind (the interconnect devices) is checked.
+    optional = [
+        line
+        for line in rendered.splitlines()
+        if line.startswith("add_optional_mount") and not line.endswith("{")
+    ]
+    assert optional == ["add_optional_mount /dev/infiniband"]
+
+
+def test_optional_mount_helper_skips_missing_paths(tmp_path):
+    """The rendered helper must skip absent host paths instead of failing."""
+    cfg = _make_cfg([], system_mounts=[tmp_path.as_posix(), "/definitely/not/here"])
+    rendered = _render_template(cfg)
+    start = rendered.index("add_optional_mount() {")
+    end = rendered.index('add_optional_mount "/definitely/not/here"') + len(
+        'add_optional_mount "/definitely/not/here"'
+    )
+    script = 'MOUNTS="base"\n' + rendered[start:end] + '\necho "$MOUNTS"'
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=True).stdout
+    assert f"base,{tmp_path.as_posix()}" in out
+    assert "/definitely/not/here" not in out.splitlines()[-1]
+
+
+def test_system_mounts_field_defaults_to_empty_list():
+    cfg = _slurm_config()
+    assert cfg.system_mounts == []
+
+
+def test_system_mounts_resolved_from_defaults_file(monkeypatch, tmp_path):
+    from domyn_swarm.config import defaults as defaults_mod
+
+    defaults_file = tmp_path / "defaults.yaml"
+    defaults_file.write_text("slurm:\n  system_mounts:\n    - /site/prod/opt\n")
+    monkeypatch.setenv("DOMYN_SWARM_DEFAULTS", str(defaults_file))
+    defaults_mod.reload_defaults_cache()
+    try:
+        assert _slurm_config().system_mounts == ["/site/prod/opt"]
+    finally:
+        defaults_mod.reload_defaults_cache()
+
+
+def test_relative_system_mount_source_rejected():
+    with pytest.raises(ValueError):
+        _slurm_config(system_mounts=["relative/path"])

--- a/tests/backends/test_slurm_mounts.py
+++ b/tests/backends/test_slurm_mounts.py
@@ -138,17 +138,27 @@ def test_base_mounts_have_no_system_mounts_by_default():
 
 
 def test_optional_mount_helper_skips_missing_paths(tmp_path):
-    """The rendered helper must skip absent host paths instead of failing."""
-    cfg = _make_cfg([], system_mounts=[tmp_path.as_posix(), "/definitely/not/here"])
-    rendered = _render_template(cfg)
+    """The rendered helper must skip absent host paths instead of failing.
+
+    Runs only the helper definition, with calls of its own, so the result does
+    not depend on which of the template's own optional paths happen to exist on
+    the machine running the tests.
+    """
+    rendered = _render_template(_make_cfg([]))
     start = rendered.index("add_optional_mount() {")
-    end = rendered.index('add_optional_mount "/definitely/not/here"') + len(
-        'add_optional_mount "/definitely/not/here"'
+    helper = rendered[start : rendered.index("\n}\n", start) + 3]
+    script = "\n".join(
+        [
+            'MOUNTS="base"',
+            helper,
+            f'add_optional_mount "{tmp_path.as_posix()}"',
+            'add_optional_mount "/definitely/not/here"',
+            'echo "$MOUNTS"',
+        ]
     )
-    script = 'MOUNTS="base"\n' + rendered[start:end] + '\necho "$MOUNTS"'
-    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=True).stdout
-    assert f"base,{tmp_path.as_posix()}" in out
-    assert "/definitely/not/here" not in out.splitlines()[-1]
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=True)
+    assert proc.stdout.splitlines()[-1] == f"base,{tmp_path.as_posix()}"
+    assert "skipping bind mount '/definitely/not/here'" in proc.stdout
 
 
 def test_system_mounts_field_defaults_to_empty_list():

--- a/tests/cli/test_init_defaults.py
+++ b/tests/cli/test_init_defaults.py
@@ -116,14 +116,16 @@ def test_yesno_passthrough(monkeypatch):
 
 def test_configure_slurm_defaults_sets_expected_fields(monkeypatch):
     # Order of prompts in _configure_slurm_defaults:
-    # image, partition, account, qos, requeue(confirm), nginx_image,
-    # port, poll, cpus, mem, tpc, wall, proxy_buf(confirm), nginx_timeout
+    # image, partition, account, qos, requeue(confirm), system_mounts,
+    # nginx_image, port, poll, cpus, mem, tpc, wall, proxy_buf(confirm),
+    # nginx_timeout
     prompt_answers = iter(
         [
             "img.sif",  # image
             "p",  # partition
             "acc",  # account
             "",  # qos (optional -> omitted)
+            "/site/prod/opt, /site/scratch",  # system_mounts
             "nginx.sif",  # nginx_image
             "9001",  # port
             "7",  # poll
@@ -151,6 +153,7 @@ def test_configure_slurm_defaults_sets_expected_fields(monkeypatch):
     assert out["slurm"]["account"] == "acc"
     assert "qos" not in out.get("slurm", {})
     assert out["slurm"]["requeue"] is True
+    assert out["slurm"]["system_mounts"] == ["/site/prod/opt", "/site/scratch"]
 
     ep = out["slurm"]["endpoint"]
     assert ep["nginx_image"] == "nginx.sif"


### PR DESCRIPTION
# What does this PR do?

Adds support for site-specific bind mounts in configuration