### PR TITLE
feat(slurm): make the watchdog collector port configurable

### DIFF
--- a/docs/concepts/watchdog-collector.md
+++ b/docs/concepts/watchdog-collector.md
@@ -45,6 +45,14 @@ submission environment overrides it for that swarm. The host is always the
 load-balancer node, and replicas read both values from the swarm's
 `serving/collector.env`.
 
+A collector that cannot bind that port — something else on the node already
+owns it — exits with `collector: FATAL: cannot bind <host>:<port>: ...` in
+`logs/collector.log`. The load-balancer job waits for the collector to create
+`run/collector.ready` before it carries on, and fails with that log excerpt if
+it never appears. Watchdogs tolerate a collector that is missing, so without
+that gate the swarm would serve traffic normally while reporting no replica
+health at all, indistinguishable from a swarm that has only just started.
+
 ## Why a single writer
 
 This is the design decision the split exists to make.

--- a/docs/concepts/watchdog-collector.md
+++ b/docs/concepts/watchdog-collector.md
@@ -39,6 +39,12 @@ One collector runs per swarm, on the load-balancer node
 Watchdogs find it via `--collector-address host:port`, which the Slurm backend
 injects. You do not normally wire this by hand.
 
+The port defaults to `9100` and is configurable as
+`backend.endpoint.collector_port`; a `COLLECTOR_PORT` variable exported in the
+submission environment overrides it for that swarm. The host is always the
+load-balancer node, and replicas read both values from the swarm's
+`serving/collector.env`.
+
 ## Why a single writer
 
 This is the design decision the split exists to make.

--- a/src/domyn_swarm/backends/serving/slurm_driver.py
+++ b/src/domyn_swarm/backends/serving/slurm_driver.py
@@ -158,7 +158,7 @@ class SlurmDriver:
             "--dependency",
             f"after:{dep_jobid}",
             "--export",
-            f"DEP_JOBID={dep_jobid}",
+            f"ALL,DEP_JOBID={dep_jobid}",
             script_path,
         ]
         out = subprocess.check_output(cmd, text=True).strip()

--- a/src/domyn_swarm/config/slurm.py
+++ b/src/domyn_swarm/config/slurm.py
@@ -240,6 +240,16 @@ class SlurmEndpointConfig(BaseModel):
         default=9000,
         description="External port exposed by the Nginx load balancer.",
     )
+    collector_port: int = Field(
+        default=9100,
+        description=(
+            "TCP port on the load-balancer node where the watchdog collector "
+            "listens for replica status updates. Replicas read the resolved "
+            "address from the swarm's `serving/collector.env`, so only the load "
+            "balancer needs this. A `COLLECTOR_PORT` variable exported in the "
+            "submission environment overrides it."
+        ),
+    )
     nginx_image: str | utils.EnvPath = Field(
         default_factory=default_for("slurm.endpoint.nginx_image"),
         description=(

--- a/src/domyn_swarm/runtime/collector.py
+++ b/src/domyn_swarm/runtime/collector.py
@@ -14,7 +14,8 @@ Example (in LB job):
   python3 /opt/watchdog_collector.py \
     --db /path/to/swarms/<name>/watchdog.db \
     --host 0.0.0.0 \
-    --port 9100
+    --port 9100 \
+    --ready-file /path/to/swarms/<name>/run/collector.ready
 
 Watchdog instances then send small JSON blobs via TCP to <host>:<port>.
 """
@@ -195,7 +196,99 @@ def upsert_status(conn: sqlite3.Connection, payload: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def run_collector(db_path: Path, host: str, port: int) -> int:
+def _bind_listener(host: str, port: int) -> socket.socket | None:
+    """
+    Bind and listen on (host, port).
+
+    Args:
+        host: IP or hostname to bind to.
+        port: TCP port to bind to.
+
+    Returns:
+        The listening socket, or None if the port could not be bound, in which
+        case the reason has been reported on stderr.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, port))
+        sock.listen(128)  # now the kernel actually accepts connections
+    except OSError as e:
+        print(f"collector: FATAL: cannot bind {host}:{port}: {e}", file=sys.stderr)
+        with contextlib.suppress(Exception):
+            sock.close()
+        return None
+    sock.settimeout(1.0)  # allow periodic checks for shutdown
+    return sock
+
+
+def _write_ready_file(ready_file: Path | None, port: int) -> bool:
+    """
+    Record the port the collector is listening on.
+
+    Args:
+        ready_file: Path to create, or None to skip the announcement.
+        port: Port the socket is bound to, written as the file's content.
+
+    Returns:
+        True on success; False if the file could not be written, in which case
+        the reason has been reported on stderr.
+    """
+    if ready_file is None:
+        return True
+    try:
+        ready_file.write_text(f"{port}\n")
+    except OSError as e:
+        print(
+            f"collector: FATAL: cannot write ready file {ready_file}: {e}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _clear_ready_file(ready_file: Path | None) -> None:
+    """
+    Remove the ready file so a dead collector no longer looks listening.
+
+    Args:
+        ready_file: Path to remove, or None when no ready file is in use.
+    """
+    if ready_file is None:
+        return
+    with contextlib.suppress(OSError):
+        ready_file.unlink(missing_ok=True)
+
+
+def _start_listening(host: str, port: int, ready_file: Path | None) -> socket.socket | None:
+    """
+    Bring the collector's socket up and announce that it is ready.
+
+    Args:
+        host: IP or hostname to bind to.
+        port: TCP port to bind to.
+        ready_file: Path to create once the socket accepts connections, or None.
+
+    Returns:
+        The listening socket, or None if the collector cannot serve, in which
+        case the reason has been reported on stderr.
+    """
+    sock = _bind_listener(host, port)
+    if sock is None:
+        return None
+    if not _write_ready_file(ready_file, sock.getsockname()[1]):
+        with contextlib.suppress(Exception):
+            sock.close()
+        return None
+    return sock
+
+
+def run_collector(
+    db_path: Path,
+    host: str,
+    port: int,
+    ready_file: Path | None = None,
+) -> int:
     """
     Main collector loop.
 
@@ -203,16 +296,25 @@ def run_collector(db_path: Path, host: str, port: int) -> int:
     Each message describes the status of one replica, which is upserted into
     the replica_status table in the SQLite DB at db_path.
 
-    Returns exit code (0=clean shutdown).
+    Args:
+        db_path: Path to the swarm-local watchdog SQLite database.
+        host: IP or hostname to bind the TCP socket to.
+        port: TCP port to listen on.
+        ready_file: Optional path to create, holding the bound port, once the
+            socket accepts connections; removed again on shutdown. It lets a
+            supervisor tell "listening" from "died while starting up", which a
+            TCP probe cannot when another process owns the port.
+
+    Returns:
+        Exit code: 0 on clean shutdown, 1 when the socket could not be bound.
     """
     conn = open_db(db_path)
 
-    # TCP server socket
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((host, port))
-    sock.listen(128)  # now the kernel actually accepts connections
-    sock.settimeout(1.0)  # allow periodic checks for shutdown
+    sock = _start_listening(host, port, ready_file)
+    if sock is None:
+        with contextlib.suppress(Exception):
+            conn.close()
+        return 1
 
     hostname = socket.gethostname()
     print(
@@ -302,6 +404,7 @@ def run_collector(db_path: Path, host: str, port: int) -> int:
         with contextlib.suppress(Exception):
             conn.close()
             sock.close()
+        _clear_ready_file(ready_file)
 
     print("collector: shutting down.", file=sys.stderr)
     return 0
@@ -328,6 +431,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=9100,
         help="TCP port to listen on (default: 9100).",
     )
+    p.add_argument(
+        "--ready-file",
+        default=None,
+        help=(
+            "Path to create once the socket is listening, holding the bound "
+            "port; removed on shutdown. Lets the load-balancer job tell a "
+            "listening collector from one that died while starting."
+        ),
+    )
     return p.parse_args(argv)
 
 
@@ -335,7 +447,12 @@ def main(argv: list[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
     args = _parse_args(argv)
-    return run_collector(Path(args.db), args.host, args.port)
+    return run_collector(
+        Path(args.db),
+        args.host,
+        args.port,
+        Path(args.ready_file) if args.ready_file else None,
+    )
 
 
 if __name__ == "__main__":

--- a/src/domyn_swarm/templates/_collector.sh.j2
+++ b/src/domyn_swarm/templates/_collector.sh.j2
@@ -1,0 +1,55 @@
+# Watchdog collector startup: launch it and prove it is listening.
+#
+# The including script must define, before calling any of this:
+#   collector_cmd        - function running the collector in the foreground,
+#                          passing --ready-file "$COLLECTOR_READY_FILE"
+#   COLLECTOR_LOG        - file the collector's output is appended to
+#   COLLECTOR_READY_FILE - path the collector creates once it has bound its port
+#   COLLECTOR_HOST       - host replicas reach the collector on (for logging)
+#   COLLECTOR_PORT       - port the collector is expected to listen on
+
+COLLECTOR_START_TIMEOUT_S="${COLLECTOR_START_TIMEOUT_S:-60}"
+
+collector_spawn() {
+    rm -f "$COLLECTOR_READY_FILE"
+    collector_cmd >>"$COLLECTOR_LOG" 2>&1 &
+    COLLECTOR_PID=$!
+}
+
+# Waits for the collector's own ready file rather than probing the port: when
+# another process already owns that port, a TCP connect succeeds while the
+# collector is dead. Gives up as soon as the process is gone, so a port
+# conflict surfaces immediately instead of looking like a slow start.
+collector_wait_ready() {
+    local deadline
+    deadline=$(( $(date +%s) + COLLECTOR_START_TIMEOUT_S ))
+    while true; do
+        if [ -f "$COLLECTOR_READY_FILE" ]; then
+            return 0
+        fi
+        if ! kill -0 "$COLLECTOR_PID" 2>/dev/null; then
+            return 1
+        fi
+        if (( $(date +%s) > deadline )); then
+            return 1
+        fi
+        sleep 0.2
+    done
+}
+
+# A swarm whose collector never started serves traffic but reports no replica
+# health at all, and nothing downstream can tell that from a collector that is
+# merely slow, so say why and refuse to carry on.
+collector_start_or_die() {
+    collector_spawn
+    if collector_wait_ready; then
+        echo "[lb] collector listening on $COLLECTOR_HOST:$COLLECTOR_PORT (PID $COLLECTOR_PID)"
+        return 0
+    fi
+    echo "[lb] ERROR: collector failed to start on port $COLLECTOR_PORT" >&2
+    echo "[lb] ---- last 20 lines of $COLLECTOR_LOG ----" >&2
+    tail -n 20 "$COLLECTOR_LOG" >&2 2>/dev/null || true
+    echo "[lb] -------------------------------------------" >&2
+    kill "$COLLECTOR_PID" 2>/dev/null || true
+    return 1
+}

--- a/src/domyn_swarm/templates/lb.sh.j2
+++ b/src/domyn_swarm/templates/lb.sh.j2
@@ -26,7 +26,7 @@ NGINX_IMG={{ cfg.backend.endpoint.nginx_image }}
 PYTHON_IMG={{ cfg.image }}
 INSTANCE_NAME="lb_${DEP_JOBID}_${SLURM_JOB_ID}"
 
-COLLECTOR_PORT="${COLLECTOR_PORT:-9100}"
+COLLECTOR_PORT="${COLLECTOR_PORT:-{{ cfg.backend.endpoint.collector_port }}}"
 COLLECTOR_HOST="$(hostname -f)"
 
 mkdir -p "$HOST_DIR" "$SERVING_DIR"

--- a/src/domyn_swarm/templates/lb.sh.j2
+++ b/src/domyn_swarm/templates/lb.sh.j2
@@ -28,23 +28,30 @@ INSTANCE_NAME="lb_${DEP_JOBID}_${SLURM_JOB_ID}"
 
 COLLECTOR_PORT="${COLLECTOR_PORT:-{{ cfg.backend.endpoint.collector_port }}}"
 COLLECTOR_HOST="$(hostname -f)"
+COLLECTOR_LOG="$HOST_DIR/logs/collector.log"
+COLLECTOR_READY_FILE="$HOST_DIR/run/collector.ready"
 
-mkdir -p "$HOST_DIR" "$SERVING_DIR"
+mkdir -p "$HOST_DIR" "$SERVING_DIR" "$HOST_DIR/run" "$HOST_DIR/logs"
 
-singularity exec --writable-tmpfs --bind "{{ collector_script_path }}:/opt/watchdog_collector.py,$HOST_DIR" "$PYTHON_IMG" \
-  python3 /opt/watchdog_collector.py \
-  --db "$HOST_DIR/watchdog.db" \
-  --host "0.0.0.0" \
-  --port "$COLLECTOR_PORT" \
-  >>"$HOST_DIR/logs/collector.log" 2>&1 &
-COLLECTOR_PID=$!
+collector_cmd() {
+  singularity exec --writable-tmpfs --bind "{{ collector_script_path }}:/opt/watchdog_collector.py,$HOST_DIR" "$PYTHON_IMG" \
+    python3 /opt/watchdog_collector.py \
+    --db "$HOST_DIR/watchdog.db" \
+    --host "0.0.0.0" \
+    --port "$COLLECTOR_PORT" \
+    --ready-file "$COLLECTOR_READY_FILE"
+}
 
+{% include "_collector.sh.j2" %}
+
+# Replicas block until this file exists, so write it up front: a collector that
+# fails to start takes the whole job down a few lines below anyway.
 {
     echo "COLLECTOR_HOST=$COLLECTOR_HOST"
     echo "COLLECTOR_PORT=$COLLECTOR_PORT"
-} > "$HOST_DIR/serving/collector.env"
+} > "$SERVING_DIR/collector.env"
 
-echo "[lb] started collector on $COLLECTOR_HOST:$COLLECTOR_PORT with PID $COLLECTOR_PID"
+collector_start_or_die
 
 trap 'echo "[lb] shutting down collector"; kill $COLLECTOR_PID' EXIT
 
@@ -64,8 +71,6 @@ while true; do
     sleep 5
 done
 echo "[lb] all replicas ready"
-
-mkdir -p "$HOST_DIR/run"
 
 # Initial upstreams config (one-shot) before nginx starts.
 singularity exec --writable-tmpfs --bind "{{ supervisor_script_path }}:/opt/lb_supervisor.py,$HOST_DIR" "$PYTHON_IMG" \

--- a/tests/backends/test_lb_template.py
+++ b/tests/backends/test_lb_template.py
@@ -26,7 +26,7 @@ def _cfg(gpu_enabled, ray_enabled=False):
         gpu_exporter=gx,
         ray_metrics=rx,
     )
-    ep = SimpleNamespace(port=9000, monitoring=mon)
+    ep = SimpleNamespace(port=9000, collector_port=9100, monitoring=mon)
     backend = SimpleNamespace(
         endpoint=ep, requires_ray=False, ray_dashboard_port=8265, ray_port=6379
     )

--- a/tests/backends/test_lb_template_render.py
+++ b/tests/backends/test_lb_template_render.py
@@ -167,6 +167,15 @@ def test_lb_still_starts_collector():
     assert "watchdog_collector.py" in out
 
 
+def test_lb_gates_startup_on_a_listening_collector():
+    out = _render_lb()
+    # The collector is launched through the lifecycle helpers, which prove it
+    # bound its port before the job carries on.
+    assert "collector_wait_ready()" in out
+    assert "collector_start_or_die" in out
+    assert '--ready-file "$COLLECTOR_READY_FILE"' in out
+
+
 def _cfg_with_monitoring(enabled: bool):
     class Mon:
         pass

--- a/tests/backends/test_lb_template_render.py
+++ b/tests/backends/test_lb_template_render.py
@@ -94,6 +94,7 @@ class _EP:
     nginx_image = "/img/nginx.sif"
     nginx_timeout = "60s"
     enable_proxy_buffering = True
+    collector_port = 9100
     monitoring = SimpleNamespace(
         enabled=False,
         mode="container",

--- a/tests/backends/test_slurm_driver.py
+++ b/tests/backends/test_slurm_driver.py
@@ -73,7 +73,7 @@ def test_submit_endpoint(mock_get_template, mock_check_output, slurm_driver, tmp
             "--dependency",
             "after:12345",
             "--export",
-            "DEP_JOBID=12345",
+            "ALL,DEP_JOBID=12345",
             ANY,
         ],
         text=True,
@@ -103,6 +103,33 @@ def test_lb_template_uses_endpoint_qos_override(dummy_config, endpoint_qos, expe
     )
 
     assert f"#SBATCH --qos={expected_qos}" in rendered
+
+
+def _render_lb(cfg):
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(cfg.backend.template_path.parent),
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    return env.get_template("lb.sh.j2").render(
+        cfg=cfg,
+        job_name="test_lb_job",
+        dep_jobid=12345,
+        replicas=4,
+        swarm_directory="/tmp/swarm",
+        collector_script_path="/tmp/collector.py",
+        supervisor_script_path="/tmp/supervisor.py",
+    )
+
+
+def test_lb_template_defaults_collector_port_to_9100(dummy_config):
+    assert 'COLLECTOR_PORT="${COLLECTOR_PORT:-9100}"' in _render_lb(dummy_config)
+
+
+def test_lb_template_uses_configured_collector_port(dummy_config):
+    dummy_config.backend.endpoint.collector_port = 9200
+    assert 'COLLECTOR_PORT="${COLLECTOR_PORT:-9200}"' in _render_lb(dummy_config)
 
 
 @patch("domyn_swarm.backends.serving.slurm_driver.subprocess.check_output")

--- a/tests/runtime/test_collector_start_gate.py
+++ b/tests/runtime/test_collector_start_gate.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behaviour of the collector startup helpers used by the lb job."""
+
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import textwrap
+
+import jinja2
+import pytest
+
+from .helpers import get_free_port
+
+pytestmark = pytest.mark.integration
+
+TEMPLATES = Path(__file__).resolve().parents[2] / "src" / "domyn_swarm" / "templates"
+
+
+def _collector_helpers() -> str:
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(TEMPLATES),
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    return env.get_template("_collector.sh.j2").render()
+
+
+def _run_driver(tmp_path: Path, body: str, name: str = "driver.sh") -> subprocess.CompletedProcess:
+    script = tmp_path / name
+    script.write_text(f"{_collector_helpers()}\n{textwrap.dedent(body)}")
+    return subprocess.run(
+        ["bash", script.as_posix()],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=tmp_path,
+    )
+
+
+def _driver_preamble(tmp_path: Path, port: int) -> str:
+    return f"""
+        COLLECTOR_LOG="{tmp_path}/collector.log"
+        COLLECTOR_READY_FILE="{tmp_path}/collector.ready"
+        COLLECTOR_HOST="localhost"
+        COLLECTOR_PORT={port}
+        COLLECTOR_START_TIMEOUT_S=20
+        : >"$COLLECTOR_LOG"
+    """
+
+
+def _real_collector_cmd(tmp_path: Path) -> str:
+    return f"""
+        collector_cmd() {{
+            "{sys.executable}" -m domyn_swarm.runtime.collector \\
+              --db "{tmp_path}/watchdog.db" \\
+              --host 127.0.0.1 \\
+              --port "$COLLECTOR_PORT" \\
+              --ready-file "$COLLECTOR_READY_FILE"
+        }}
+    """
+
+
+def test_gate_fails_when_the_collector_cannot_bind_its_port(tmp_path):
+    with socket.socket() as blocker:
+        blocker.bind(("127.0.0.1", 0))
+        blocker.listen(1)
+        port = blocker.getsockname()[1]
+
+        proc = _run_driver(
+            tmp_path,
+            f"""
+            set -eu
+            {_driver_preamble(tmp_path, port)}
+            {_real_collector_cmd(tmp_path)}
+            collector_start_or_die
+            echo GATE-OK
+            """,
+        )
+
+    assert proc.returncode != 0
+    assert "GATE-OK" not in proc.stdout
+    assert "collector failed to start" in proc.stderr
+    # The operator gets the reason, not just the fact.
+    assert "cannot bind" in proc.stderr.lower()
+    assert str(port) in proc.stderr
+
+
+def test_gate_passes_once_the_collector_is_listening(tmp_path):
+    port = get_free_port()
+    proc = _run_driver(
+        tmp_path,
+        f"""
+        set -eu
+        {_driver_preamble(tmp_path, port)}
+        {_real_collector_cmd(tmp_path)}
+        collector_start_or_die
+        echo GATE-OK
+        kill "$COLLECTOR_PID"
+        """,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "GATE-OK" in proc.stdout
+    assert f"collector listening on localhost:{port}" in proc.stdout

--- a/tests/runtime/test_collector_startup.py
+++ b/tests/runtime/test_collector_startup.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025-2026 Domyn
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+from .helpers import get_free_port, wait_for_port
+
+pytestmark = pytest.mark.integration
+
+
+def _collector_cmd(db_path: Path, port: int, ready_file: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "domyn_swarm.runtime.collector",
+        "--db",
+        db_path.as_posix(),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--ready-file",
+        ready_file.as_posix(),
+    ]
+
+
+def test_collector_fails_with_a_clear_error_when_its_port_is_taken(tmp_path):
+    ready_file = tmp_path / "collector.ready"
+
+    with socket.socket() as blocker:
+        blocker.bind(("127.0.0.1", 0))
+        blocker.listen(1)
+        port = blocker.getsockname()[1]
+
+        proc = subprocess.run(
+            _collector_cmd(tmp_path / "watchdog.db", port, ready_file),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    assert proc.returncode == 1, proc.stderr
+    assert "cannot bind" in proc.stderr.lower()
+    assert str(port) in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert not ready_file.exists()
+
+
+def test_collector_writes_ready_file_with_the_bound_port(tmp_path):
+    port = get_free_port()
+    ready_file = tmp_path / "collector.ready"
+
+    proc = subprocess.Popen(
+        _collector_cmd(tmp_path / "watchdog.db", port, ready_file),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.time() + 15.0
+        while time.time() < deadline and not ready_file.exists():
+            assert proc.poll() is None, proc.communicate()[1]
+            time.sleep(0.05)
+
+        assert ready_file.exists()
+        assert ready_file.read_text().strip() == str(port)
+        # The file only appears once the socket really accepts connections.
+        wait_for_port("127.0.0.1", port, timeout=5.0)
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+    assert not ready_file.exists()


### PR DESCRIPTION
# What does this PR do?

A user reported a swarm that came up and served traffic normally while
reporting no replica health at all. The cause is a port conflict: the watchdog
collector's port was hardcoded to 9100, which is also node_exporter's default,
so `sock.bind` failed, the collector died immediately — and nothing noticed.

Nothing *could* notice. The collector is launched in the background from the lb
script, watchdogs tolerate a missing collector by design (for a late start), and
every reader treats "no rows" as "not written yet": `read_replica_statuses`
returns `[]` for a missing DB, a missing table or any sqlite error, and readiness
only waits on `GET /health` through nginx. A dead collector and a slow one look
identical, so the swarm ran blind: no live replica counts during `up`, no early
abort when all replicas fail, an empty health table in `domyn-swarm status`.

Two commits, one per half of the problem.

**The port is configurable** (`feat(slurm): make the watchdog collector port configurable`)

- New `backend.endpoint.collector_port`, default `9100`.
- The lb template renders it as the fallback for `${COLLECTOR_PORT:-…}`.
- The lb job is submitted with `--export ALL,DEP_JOBID=<id>` instead of
  `--export DEP_JOBID=<id>`, so an exported `COLLECTOR_PORT` reaches the script.
  Previously only `SLURM_*` and `DEP_JOBID` were propagated, which made the
  env-var indirection already in the template dead code.

Precedence: exported `COLLECTOR_PORT` → `endpoint.collector_port` → 9100.
Replicas need nothing; they still read host and port from `serving/collector.env`.

**Failure is loud** (`fix(slurm): fail the lb job when the collector cannot start`)

- A bind failure prints one line — `collector: FATAL: cannot bind 0.0.0.0:9100:
  [Errno 98] Address already in use` — and exits 1, instead of a raw traceback.
- New `--ready-file`, created after `listen()` with the bound port as its content
  and removed on shutdown.
- New `_collector.sh.j2`, included by the lb script: `collector_start_or_die`
  spawns the collector and waits for that file, giving up as soon as the process
  is gone or `COLLECTOR_START_TIMEOUT_S` (60s) passes, printing the port and the
  last 20 lines of `logs/collector.log`. Under `set -eu` the lb job then exits,
  so `up` fails with `LB job ended in FAILED`.

Readiness comes from the ready file rather than a TCP probe on purpose: a foreign
process holding the port answers a connect while the collector is dead, so a
probe would report success in exactly this failure case.

`collector.env` is still written *before* the gate — replicas block forever on
that file, and a failing gate takes the deployment down anyway.

### Behaviour changes to be aware of

- A collector that cannot bind now fails the deployment instead of degrading
  silently. That is the point of the PR, but it does turn a previously survivable
  condition into a hard failure.
- The lb job now inherits the full submission environment, where it previously
  saw only `DEP_JOBID`. This matches what the replicas job already does
  (`--export=ALL`).

### Out of scope

- A collector that dies *later* still goes unnoticed; the gate only covers
  startup.
- `read_replica_statuses` still cannot distinguish "no data" from "no collector",
  so `status` stays ambiguous for a mid-run death.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/igeniusai/domyn-swarm/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/igeniusai/domyn-swarm/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/igeniusai/domyn-swarm/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

Docs: `docs/concepts/watchdog-collector.md` covers the port knob and the startup
gate; the configuration reference table is generated from the Pydantic field
description, so it picks up `collector_port` automatically.

Tests: `tests/runtime/test_collector_startup.py` runs the real collector against
a port the test holds (exit 1, `cannot bind` and the port in stderr, no
traceback, no ready file) and on a free port (ready file appears with the bound
port, disappears on shutdown). `tests/runtime/test_collector_start_gate.py`
renders the shell helpers and runs them under bash with the real collector: the
gate fails on a taken port with the reason in stderr, passes on a free one. Plus
render assertions for the config-driven port, the `--ready-file` wiring and the
sbatch export list. `uv run pytest` → 1233 passed, 2 skipped; ruff and pyright
clean.
